### PR TITLE
Code cleanup, small tweaks to code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -470,3 +470,7 @@ dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net
 ##########################################
 # Custom - Code Analyzers Rules
 ##########################################
+
+dotnet_diagnostic.CA1014.severity = none    # CA1014: Mark assemblies with CLSCompliant
+
+dotnet_diagnostic.SA1202.severity = none    # SA1202: Elements should be ordered by access

--- a/Atc.Rest.Client.sln
+++ b/Atc.Rest.Client.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Rest.Client", "src\Atc.Rest.Client\Atc.Rest.Client.csproj", "{15A96F3F-4F3D-471D-885F-8C817EE0799E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Rest.Client.Tests", "test\Atc.Rest.Client.Tests\Atc.Rest.Client.Tests.csproj", "{2286E363-C6E4-41AB-9A03-FC8C4C8FEB79}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{15A96F3F-4F3D-471D-885F-8C817EE0799E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15A96F3F-4F3D-471D-885F-8C817EE0799E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{15A96F3F-4F3D-471D-885F-8C817EE0799E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2286E363-C6E4-41AB-9A03-FC8C4C8FEB79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2286E363-C6E4-41AB-9A03-FC8C4C8FEB79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2286E363-C6E4-41AB-9A03-FC8C4C8FEB79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2286E363-C6E4-41AB-9A03-FC8C4C8FEB79}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Atc.Rest.Client.sln
+++ b/Atc.Rest.Client.sln
@@ -7,6 +7,33 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Rest.Client", "src\Atc.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Rest.Client.Tests", "test\Atc.Rest.Client.Tests\Atc.Rest.Client.Tests.csproj", "{2286E363-C6E4-41AB-9A03-FC8C4C8FEB79}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".files", ".files", "{B301C360-29E2-4F7B-93DA-58F8EBF1C822}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		version.json = version.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".text", ".text", "{C17073B2-67F2-4DFD-A077-23F6A5C79F7C}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6F93C17A-E567-4E32-AE28-5AF20CBC7A2B}"
+	ProjectSection(SolutionItems) = preProject
+		src\.editorconfig = src\.editorconfig
+		src\directory.build.props = src\directory.build.props
+		src\directory.build.targets = src\directory.build.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D98D5EEC-459E-40AF-8C0F-92F03BF084C4}"
+	ProjectSection(SolutionItems) = preProject
+		test\.editorconfig = test\.editorconfig
+		test\directory.build.props = test\directory.build.props
+		test\directory.build.targets = test\directory.build.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,6 +51,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{15A96F3F-4F3D-471D-885F-8C817EE0799E} = {6F93C17A-E567-4E32-AE28-5AF20CBC7A2B}
+		{2286E363-C6E4-41AB-9A03-FC8C4C8FEB79} = {D98D5EEC-459E-40AF-8C0F-92F03BF084C4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A92D7EC-F444-456B-A86C-D6683E016C35}

--- a/src/Atc.Rest.Client/Atc.Rest.Client.csproj
+++ b/src/Atc.Rest.Client/Atc.Rest.Client.csproj
@@ -43,7 +43,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest.Client/Authentication/BearerTokenProvider.cs
+++ b/src/Atc.Rest.Client/Authentication/BearerTokenProvider.cs
@@ -20,7 +20,11 @@ namespace Atc.Rest.Client.Authentication
             }
 
             credential = options.Credential;
-            context = new TokenRequestContext(new string[] { options.IdentityScope });
+
+            // !BANG added to make nullable analyzer happy, since .netstandard2
+            // doesn't include annotations in IsNullOrWhiteSpace that tells the analyzer
+            // that options.IdentityScope cannot be null if it returns true.
+            context = new TokenRequestContext(new string[] { options.IdentityScope! });
         }
 
         public async Task<AuthenticationHeaderValue> GetTokenAsync(CancellationToken cancellationToken)

--- a/src/Atc.Rest.Client/Builder/HttpMessageFactory.cs
+++ b/src/Atc.Rest.Client/Builder/HttpMessageFactory.cs
@@ -3,7 +3,7 @@ using Atc.Rest.Client.Serialization;
 
 namespace Atc.Rest.Client.Builder
 {
-    public class HttpMessageFactory : IHttpMessageFactory
+    internal class HttpMessageFactory : IHttpMessageFactory
     {
         private readonly IContractSerializer serializer;
 
@@ -12,8 +12,8 @@ namespace Atc.Rest.Client.Builder
             this.serializer = serializer;
         }
 
-        public IMessageRequestBuilder FromTemplate(string template)
-            => new MessageRequestBuilder(template, serializer);
+        public IMessageRequestBuilder FromTemplate(string pathTemplate)
+            => new MessageRequestBuilder(pathTemplate, serializer);
 
         public IMessageResponseBuilder FromResponse(HttpResponseMessage? response)
             => new MessageResponseBuilder(response, serializer);

--- a/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
+++ b/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
@@ -1,10 +1,26 @@
+using System;
 using System.Net.Http;
 
 namespace Atc.Rest.Client.Builder
 {
+    /// <summary>
+    /// Represents a HTTP message factory that can create both the <see cref="IMessageRequestBuilder"/>
+    /// and <see cref="IMessageRequestBuilder"/>, used to provide input to
+    /// and processes responses from an HTTP exchange.
+    /// </summary>
     public interface IHttpMessageFactory
     {
-        IMessageRequestBuilder FromTemplate(string template);
+        /// <summary>
+        /// Start building a <see cref="HttpRequestMessage"/> with the
+        /// returned <see cref="IMessageRequestBuilder"/>, which will use the provided
+        /// <paramref name="pathTemplate"/> as the request URI.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="pathTemplate"/> is null.</exception>
+        /// <param name="pathTemplate">The relative URI to request. Can contain tokens values,
+        /// that will be with real values pass to the <see cref="IMessageRequestBuilder.WithPathParameter(string, string)"/>
+        /// method.</param>
+        /// <returns>A new <see cref="IMessageRequestBuilder"/>.</returns>
+        IMessageRequestBuilder FromTemplate(string pathTemplate);
 
         IMessageResponseBuilder FromResponse(HttpResponseMessage? response);
     }

--- a/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
+++ b/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
@@ -16,8 +16,8 @@ namespace Atc.Rest.Client.Builder
         /// <paramref name="pathTemplate"/> as the request URI.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="pathTemplate"/> is null.</exception>
-        /// <param name="pathTemplate">The relative URI to request. Can contain tokens values,
-        /// that will be with real values pass to the <see cref="IMessageRequestBuilder.WithPathParameter(string, string)"/>
+        /// <param name="pathTemplate">The relative URI to request. Can contain tokens,
+        /// that will be replaced with real values pass to the <see cref="IMessageRequestBuilder.WithPathParameter(string, string)"/>
         /// method.</param>
         /// <returns>A new <see cref="IMessageRequestBuilder"/>.</returns>
         IMessageRequestBuilder FromTemplate(string pathTemplate);

--- a/src/Atc.Rest.Client/Builder/IMessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/IMessageRequestBuilder.cs
@@ -1,18 +1,81 @@
+using System;
 using System.Net.Http;
+using Atc.Rest.Client.Serialization;
 
 namespace Atc.Rest.Client.Builder
 {
+    /// <summary>
+    /// A message request builder can be used to build a <see cref="HttpRequestMessage"/>.
+    /// </summary>
     public interface IMessageRequestBuilder
     {
+        /// <summary>
+        /// Adds a value to a path parameter in a path template passed to the constructor of the <see cref="IMessageRequestBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="IMessageRequestBuilder"/> implementation is expected to get passed a path template with
+        /// optional path parameters inside, which this method will replace with the <paramref name="value"/>.
+        /// </remarks>
+        /// <param name="name">Name of the path parameter in the template path.</param>
+        /// <param name="value">Value to use as the path parameter.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="value"/> is null, empty, or whitespace.</exception>
+        /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
         IMessageRequestBuilder WithPathParameter(string name, string value);
 
+        /// <summary>
+        /// Adds a value to a path parameter in a path template passed to the constructor of the <see cref="IMessageRequestBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="IMessageRequestBuilder"/> implementation is expected to get passed a path template with
+        /// optional path parameters inside, which this method will replace with the <paramref name="value"/>.
+        /// </remarks>
+        /// <typeparam name="T">The type of the value to add.</typeparam>
+        /// <param name="name">Name of the path parameter in the template path.</param>
+        /// <param name="value">Value to use as the path parameter. It will be converted to a string
+        /// before being added as a query string, using the <c>ToString()</c> method.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="value"/> is null, empty, or whitespace.</exception>
+        /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
+        IMessageRequestBuilder WithPathParameter<T>(string name, T value)
+            where T : struct;
+
+        /// <summary>
+        /// Adds a query parameter to the created request URL.
+        /// </summary>
+        /// <remarks>
+        /// If the <paramref name="value"/> is null, the query parameter is not added.
+        /// </remarks>
+        /// <param name="name">Name of the query parameter.</param>
+        /// <param name="value">Value of the query parameter.</param>
+        /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
         IMessageRequestBuilder WithQueryParameter(string name, string? value);
 
+        /// <summary>
+        /// Adds a query parameter to the created request URL.
+        /// </summary>
+        /// <typeparam name="T">The type of the value to add.</typeparam>
+        /// <param name="name">Name of the query parameter.</param>
+        /// <param name="value">Value of the query parameter. It will be converted to a string
+        /// before being added as a query string, using the <c>ToString()</c> method.</param>
+        /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
         IMessageRequestBuilder WithQueryParameter<T>(string name, T value)
             where T : struct;
 
+        /// <summary>
+        /// Adds the body of the request.
+        /// </summary>
+        /// <remarks>
+        /// The builder should use a <see cref="IContractSerializer"/> to serialize <paramref name="body"/>.
+        /// </remarks>
+        /// <typeparam name="TBody">The type of object to add as the body of the request.</typeparam>
+        /// <param name="body">The body to add to the request.</param>
+        /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
         IMessageRequestBuilder WithBody<TBody>(TBody body);
 
+        /// <summary>
+        /// Builds a <see cref="HttpRequestMessage"/> with the added content.
+        /// </summary>
+        /// <param name="method">The <see cref="HttpMethod"/> to use in the request.</param>
+        /// <returns>The created <see cref="HttpRequestMessage"/>.</returns>
         HttpRequestMessage Build(HttpMethod method);
     }
 }

--- a/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
@@ -8,7 +8,7 @@ using Atc.Rest.Client.Serialization;
 
 namespace Atc.Rest.Client.Builder
 {
-    public class MessageRequestBuilder : IMessageRequestBuilder
+    internal class MessageRequestBuilder : IMessageRequestBuilder
     {
         private readonly string template;
         private readonly IContractSerializer serializer;

--- a/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
@@ -16,10 +16,10 @@ namespace Atc.Rest.Client.Builder
         private readonly Dictionary<string, string> queryMapper;
         private string content = string.Empty;
 
-        public MessageRequestBuilder(string template, IContractSerializer serializer)
+        public MessageRequestBuilder(string pathTemplate, IContractSerializer serializer)
         {
-            this.template = template;
-            this.serializer = serializer;
+            this.template = pathTemplate ?? throw new ArgumentNullException(nameof(pathTemplate));
+            this.serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             pathMapper = new Dictionary<string, string>(StringComparer.Ordinal);
             queryMapper = new Dictionary<string, string>(StringComparer.Ordinal);
         }
@@ -66,11 +66,16 @@ namespace Atc.Rest.Client.Builder
             return this;
         }
 
+        public IMessageRequestBuilder WithPathParameter<T>(string name, T value)
+            where T : struct
+            => WithPathParameter(name, value.ToString());
+
         public IMessageRequestBuilder WithQueryParameter(string name, string? value)
         {
             if (!string.IsNullOrEmpty(value))
             {
-                queryMapper[name] = value;
+                // BANG added because nullable analyzer doesn't understand IsNullOrEmpty in .netstandard2.0
+                queryMapper[name] = value!;
             }
 
             return this;

--- a/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
@@ -10,7 +10,7 @@ using Atc.Rest.Client.Serialization;
 
 namespace Atc.Rest.Client.Builder
 {
-    public class MessageResponseBuilder : IMessageResponseBuilder
+    internal class MessageResponseBuilder : IMessageResponseBuilder
     {
         [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1000:Keywords should be spaced correctly", Justification = "False positive. new() syntax requires it.")]
         private static readonly EndpointResponse EmptyResponse

--- a/src/Atc.Rest.Client/InternalVisibleTo.cs
+++ b/src/Atc.Rest.Client/InternalVisibleTo.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Atc.Rest.Client.Tests")]

--- a/src/Atc.Rest.Client/Options/ServiceCollectionExtensions.cs
+++ b/src/Atc.Rest.Client/Options/ServiceCollectionExtensions.cs
@@ -3,10 +3,11 @@ using Atc.Rest.Client.Authentication;
 using Atc.Rest.Client.Builder;
 using Atc.Rest.Client.Options;
 using Atc.Rest.Client.Serialization;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class AtcRestClientServiceCollectionExtensions
+    public static class ServiceCollectionExtensions
     {
         public static IServiceCollection AddAtcRestClient<TOptions>(
             this IServiceCollection services,
@@ -34,7 +35,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Register utilities
             services.AddSingleton<IHttpMessageFactory, HttpMessageFactory>();
-            services.AddSingleton<IContractSerializer, ContractSerializer>();
+            services.AddSingleton<IContractSerializer, DefaultJsonContractSerializer>();
 
             return services;
         }

--- a/src/Atc.Rest.Client/Serialization/DefaultJsonContractSerializer.cs
+++ b/src/Atc.Rest.Client/Serialization/DefaultJsonContractSerializer.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Atc.Rest.Client.Serialization
 {
-    public class ContractSerializer : IContractSerializer
+    public class DefaultJsonContractSerializer : IContractSerializer
     {
         private static readonly JsonSerializerOptions DefaultOptions = new JsonSerializerOptions
         {
@@ -19,7 +19,7 @@ namespace Atc.Rest.Client.Serialization
 
         private readonly JsonSerializerOptions options;
 
-        public ContractSerializer(JsonSerializerOptions? options = default)
+        public DefaultJsonContractSerializer(JsonSerializerOptions? options = default)
         {
             this.options = options ?? DefaultOptions;
         }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -46,3 +46,13 @@ dotnet_diagnostic.SA1133.severity = none            # https://github.com/atc-net
 ##########################################
 # Custom - Code Analyzers Rules
 ##########################################
+
+dotnet_diagnostic.CA1062.severity = none # CA1062: Validate arguments of public methods
+dotnet_diagnostic.CA1806.severity = suggestion # CA1806: Do not ignore method results
+dotnet_diagnostic.CA2007.severity = none # CA2007: Consider calling ConfigureAwait on the awaited task
+
+
+dotnet_diagnostic.SA1122.severity = suggestion # SA1122: Use string.Empty for empty strings
+
+dotnet_diagnostic.VSTHRD111.severity = none # VSTHRD111: Use ConfigureAwait(bool)
+dotnet_diagnostic.VSTHRD200.severity = none # VSTHRD200: Use "Async" suffix for async methods

--- a/test/Atc.Rest.Client.Tests/Atc.Rest.Client.Tests.csproj
+++ b/test/Atc.Rest.Client.Tests/Atc.Rest.Client.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Nullable>annotations</Nullable>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Atc.Test" Version="1.0.6" />
+    <PackageReference Include="AutoFixture" Version="4.15.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Atc.Rest.Client\Atc.Rest.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Atc.Rest.Client.Tests/Builder/HttpMessageFactoryTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/HttpMessageFactoryTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Atc.Rest.Client.Builder;
+using Atc.Rest.Client.Serialization;
+using Atc.Test;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Rest.Client.Tests.Builder
+{
+    public class HttpMessageFactoryTests
+    {
+        private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
+
+        private HttpMessageFactory CreateSut()
+            => new HttpMessageFactory(serializer);
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Provide_MessageResponseBuilder_FromResponse(
+            HttpResponseMessage response)
+            => CreateSut().FromResponse(response)
+                .Should()
+                .NotBeNull();
+
+        [Fact]
+        public void Should_Provide_MessageResponseBuilder_From_Null_Response()
+            => CreateSut().FromResponse(null)
+                .Should()
+                .NotBeNull();
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Provide_MessageRequestBuilder_FromTemplate(string template)
+            => CreateSut().FromTemplate(template)
+                .Should()
+                .NotBeNull();
+    }
+}

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Atc.Rest.Client.Builder;
+using Atc.Rest.Client.Serialization;
+using Atc.Test;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Rest.Client.Tests.Builder
+{
+    public class MessageRequestBuilderTests
+    {
+        private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
+
+        private MessageRequestBuilder CreateSut(string pathTemplate = null)
+            => new MessageRequestBuilder(pathTemplate ?? "api/", serializer);
+
+        [Fact]
+        public void Null_Path_Throws()
+        {
+            Action ctor = () => new MessageRequestBuilder(null, this.serializer);
+
+            ctor.Should()
+                .Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("pathTemplate");
+        }
+
+        [Fact]
+        public void Null_ContractSerializer_Throws()
+        {
+            Action ctor = () => new MessageRequestBuilder("", serializer: null);
+
+            ctor.Should()
+                .Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("serializer");
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Use_HttpMethod(HttpMethod method)
+            => CreateSut().Build(method)
+                .Method
+                .Should()
+                .Be(method);
+
+        [Fact]
+        public void Should_Add_ApplicationJson_To_Accept_Header_By_Default()
+        {
+            var message = CreateSut().Build(HttpMethod.Post);
+
+            message
+                .Headers
+                .Accept
+                .Should()
+                .BeEquivalentTo(new[] { MediaTypeWithQualityHeaderValue.Parse("application/json") });
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Set_Content_MediaType_To_ApplicationJson_When_Body_Is_Present(string body)
+        {
+            var sut = CreateSut();
+
+            sut.WithBody(body);
+
+            var message = sut.Build(HttpMethod.Post);
+
+            message
+                .Content
+                .Headers
+                .ContentType
+                .Should()
+                .Be(MediaTypeHeaderValue.Parse("application/json"));
+        }
+
+        [Theory]
+        [InlineData(null, "foo")]
+        [InlineData("", "foo")]
+        [InlineData(" ", "foo")]
+        [InlineData("foo", null)]
+        [InlineData("foo", "")]
+        [InlineData("foo", " ")]
+        public void WithPathParameter_Throws_If_Parmeters_Are_Null_Or_WhiteSpace(
+            string name,
+            string value)
+        {
+            var sut = CreateSut();
+
+            sut.Invoking(x => x.WithPathParameter(name, value))
+                .Should()
+                .Throw<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineAutoNSubstituteData("/api/{foo}/bar/{baz}/biz")]
+        public void Should_Replace_Path_Parameters(
+            string template,
+            string fooValue,
+            int bazValue)
+        {
+            var sut = CreateSut(template);
+
+            sut.WithPathParameter("foo", fooValue);
+            sut.WithPathParameter("baz", bazValue);
+            var message = sut.Build(HttpMethod.Post);
+
+            message
+                .RequestUri
+                .ToString()
+                .Should()
+                .Be($"/api/{fooValue}/bar/{bazValue}/biz");
+        }
+
+        [Theory]
+        [InlineAutoNSubstituteData("/api")]
+        public void Should_Replace_Query_Parameters(
+            string template,
+            string fooValue,
+            int barValue)
+        {
+            var sut = CreateSut(template);
+
+            sut.WithQueryParameter("foo", fooValue);
+            sut.WithQueryParameter("bar", barValue);
+            var message = sut.Build(HttpMethod.Post);
+
+            message
+                .RequestUri
+                .ToString()
+                .Should()
+                .Be($"/api?foo={fooValue}&bar={barValue}");
+        }
+
+        [Fact]
+        public void WithBody_Throws_If_Parmeter_Is_Null()
+        {
+            var sut = CreateSut();
+
+            sut.Invoking(x => x.WithBody<string>(null!))
+                .Should()
+                .Throw<ArgumentNullException>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Include_Body(string content)
+        {
+            serializer.Serialize(default).ReturnsForAnyArgs(x => x[0]);
+            var sut = CreateSut();
+
+            sut.WithBody(content);
+
+            var message = sut.Build(HttpMethod.Post);
+            var result = await message.Content.ReadAsStringAsync();
+
+            result
+                .Should()
+                .Be(content);
+        }
+    }
+}

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderTests.cs
@@ -134,7 +134,7 @@ namespace Atc.Rest.Client.Tests.Builder
         }
 
         [Fact]
-        public void WithBody_Throws_If_Parmeter_Is_Null()
+        public void WithBody_Throws_If_Parameter_Is_Null()
         {
             var sut = CreateSut();
 

--- a/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderTests.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Atc.Rest.Client.Builder;
+using Atc.Rest.Client.Serialization;
+using Atc.Test;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Rest.Client.Tests.Builder
+{
+    public class MessageResponseBuilderTests
+    {
+        private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
+
+        private MessageResponseBuilder CreateSut(HttpResponseMessage? response)
+            => new MessageResponseBuilder(response, serializer);
+
+        [Theory, AutoNSubstituteData]
+        public async Task IsSuccess_Should_Respect_Configured_ErrorResponse(
+           HttpResponseMessage response,
+           CancellationToken cancellationToken)
+        {
+            var sut = CreateSut(response);
+            response.StatusCode = HttpStatusCode.NotFound;
+
+            var result = await sut.AddErrorResponse(response.StatusCode)
+                .BuildResponseAsync(res => res, cancellationToken);
+
+            result
+                .IsSuccess
+                .Should()
+                .BeFalse();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task IsSuccess_Should_Respect_Configured_SuccessResponse(
+            HttpResponseMessage response,
+            CancellationToken cancellationToken)
+        {
+            var sut = CreateSut(response);
+            response.StatusCode = HttpStatusCode.NotFound;
+
+            var result = await sut.AddSuccessResponse(response.StatusCode)
+                .BuildResponseAsync(res => res, cancellationToken);
+
+            result
+                .IsSuccess
+                .Should()
+                .BeTrue();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Deserialize_Configured_SuccessResponseCode(
+            HttpResponseMessage response,
+            Guid expectedResponse,
+            CancellationToken cancellationToken)
+        {
+            serializer.Deserialize<Guid>(Arg.Any<string>()).Returns(expectedResponse);
+            var sut = CreateSut(response);
+            response.StatusCode = HttpStatusCode.OK;
+
+            var result = await sut.AddSuccessResponse<Guid>(response.StatusCode)
+                .BuildResponseAsync(res => res, cancellationToken);
+
+            result
+                .ContentObject
+                .Should()
+                .BeEquivalentTo(expectedResponse);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Deserialize_Configured_ErrorResponseCode(
+            HttpResponseMessage response,
+            Guid expectedResponse,
+            CancellationToken cancellationToken)
+        {
+            serializer.Deserialize<Guid>(Arg.Any<string>()).Returns(expectedResponse);
+            var sut = CreateSut(response);
+            response.StatusCode = HttpStatusCode.BadRequest;
+
+            var result = await sut.AddErrorResponse<Guid>(response.StatusCode)
+                .BuildResponseAsync(res => res, cancellationToken);
+
+            result
+                .ContentObject
+                .Should()
+                .BeEquivalentTo(expectedResponse);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Return_Response_Headers(
+            HttpResponseMessage response,
+            CancellationToken cancellationToken)
+        {
+            var sut = CreateSut(response);
+            var expected = new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal)
+            {
+                { "responseHeader", new[] { "value" } },
+                { "contentHeader", new[] { "value" } },
+            };
+            response.Headers.Add("responseHeader", "value");
+            response.Content.Headers.Add("contentHeader", "value");
+            response.StatusCode = HttpStatusCode.OK;
+
+            var result = await sut.AddSuccessResponse(response.StatusCode)
+                .BuildResponseAsync(res => res, cancellationToken);
+
+            result
+                .Headers
+                .Should()
+                .BeEquivalentTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
PR include no functional changes.

Here is what is changed: 

- Renamed ContractSerializer to make it clear it is the default json contract serializer included with the client.
- Moved ServiceCollectionExtensions.AddAtcRestClient into the options folder as they seem tightly related.
- Added code docs to IHttpMessageFactory, changed implementation of builders to internal. This ensures we can evolve those without breaking clients that might be using the directly.
  - Added internal visible to project to allow test project to see internal builders
- Added unit tests to the builder types. NOTE, that due to the builder implementations being internal, they cannot be created using the AutoNSubstitute trick, so the instead they are created using a helper method in the tests.
- Added `IMessageRequestBuilder WithPathParameter<T>(string name, T value) where T : struct;` to `IMessageRequestBuilder` to make it easier to pass values other than string in. 