### PR TITLE
Ensuring we dont set content, when there is no content 

### DIFF
--- a/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
+++ b/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
@@ -17,7 +17,7 @@ namespace Atc.Rest.Client.Builder
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="pathTemplate"/> is null.</exception>
         /// <param name="pathTemplate">The relative URI to request. Can contain tokens,
-        /// that will be replaced with real values pass to the <see cref="IMessageRequestBuilder.WithPathParameter(string, string)"/>
+        /// that will be replaced with real values passed to the <see cref="IMessageRequestBuilder.WithPathParameter(string, object?)"/>
         /// method.</param>
         /// <returns>A new <see cref="IMessageRequestBuilder"/>.</returns>
         IMessageRequestBuilder FromTemplate(string pathTemplate);

--- a/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
@@ -15,7 +15,7 @@ namespace Atc.Rest.Client.Builder
         private readonly Dictionary<string, string> pathMapper;
         private readonly Dictionary<string, string> headerMapper;
         private readonly Dictionary<string, string> queryMapper;
-        private string content = string.Empty;
+        private string? content;
 
         public MessageRequestBuilder(string pathTemplate, IContractSerializer serializer)
         {
@@ -24,6 +24,7 @@ namespace Atc.Rest.Client.Builder
             pathMapper = new Dictionary<string, string>(StringComparer.Ordinal);
             headerMapper = new Dictionary<string, string>(StringComparer.Ordinal);
             queryMapper = new Dictionary<string, string>(StringComparer.Ordinal);
+            WithHeaderParameter("accept", "application/json");
         }
 
         public HttpRequestMessage Build(HttpMethod method)
@@ -37,9 +38,13 @@ namespace Atc.Rest.Client.Builder
             }
 
             message.RequestUri = BuildRequestUri();
-            message.Content = new StringContent(content);
-            message.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             message.Method = method;
+
+            if (content is not null)
+            {
+                message.Content = new StringContent(content);
+                message.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            }
 
             return message;
         }


### PR DESCRIPTION
Ensuring we dont set content, when there is no content - otherwise GET/HEAD calls would fail. We cant add content to these.

Also setting default accept header in CTOR now.