### PR TITLE
Fix issue with multiple clients sharing the same options

### DIFF
--- a/src/Atc.Rest.Client/Options/ServiceCollectionExtensions.cs
+++ b/src/Atc.Rest.Client/Options/ServiceCollectionExtensions.cs
@@ -17,11 +17,10 @@ namespace Atc.Rest.Client.Options
             where TOptions : AtcRestClientOptions, new()
         {
             services.AddSingleton(options);
-            services.AddSingleton<AtcRestClientOptions>(options);
 
             var clientBuilder = services.AddHttpClient(clientName, (s, c) =>
             {
-                var o = s.GetRequiredService<AtcRestClientOptions>();
+                var o = s.GetRequiredService<TOptions>();
                 c.BaseAddress = o.BaseAddress;
                 c.Timeout = o.Timeout;
             });


### PR DESCRIPTION
Issue is that the `AtcRestClientOptions` type is used to register and read the options for the Client. Using the generic `TOptions` instead will ensure that different clients do not share the same options.