### PR TITLE
Add overload for AddAtcRestClient

### DIFF
--- a/src/Atc.Rest.Client/Options/ServiceCollectionExtensions.cs
+++ b/src/Atc.Rest.Client/Options/ServiceCollectionExtensions.cs
@@ -33,5 +33,28 @@ namespace Atc.Rest.Client.Options
 
             return services;
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static IServiceCollection AddAtcRestClient(
+            this IServiceCollection services,
+            string clientName,
+            Uri baseAddress,
+            TimeSpan timeout,
+            Action<IHttpClientBuilder>? httpClientBuilder = default)
+        {
+            var clientBuilder = services.AddHttpClient(clientName, (s, c) =>
+            {
+                c.BaseAddress = baseAddress;
+                c.Timeout = timeout;
+            });
+
+            httpClientBuilder?.Invoke(clientBuilder);
+
+            // Register utilities
+            services.AddSingleton<IHttpMessageFactory, HttpMessageFactory>();
+            services.AddSingleton<IContractSerializer, DefaultJsonContractSerializer>();
+
+            return services;
+        }
     }
 }


### PR DESCRIPTION
This PR enables us to have multiple clients without having to create empty type specific client options that inherits from AtcRestClientOptions which in effect will violate rule S2094.