### PR TITLE
fix: remove invalid 'true' argument from --no-symbols flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,4 @@ jobs:
         run: dotnet pack -c Release --no-restore -o ${GITHUB_WORKSPACE}/packages -p:RepositoryBranch=$BRANCH_NAME /p:PublicRelease=true
 
       - name: 📦 Push packages to NuGet
-        run: dotnet nuget push ${GITHUB_WORKSPACE}/packages/Atc.Rest.Client.${{ env.NBGV_NuGetPackageVersion }}.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols true
+        run: dotnet nuget push ${GITHUB_WORKSPACE}/packages/Atc.Rest.Client.${{ env.NBGV_NuGetPackageVersion }}.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols


### PR DESCRIPTION
The --no-symbols flag is a boolean switch that doesn't accept a value. When 'true' was passed, dotnet interpreted it as a file path to push, causing "File does not exist (true)" error after successful package push.