### PR TITLE
Add InvalidContentAccessException helpers and make response cla…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ A lightweight and flexible REST client library for .NET, providing a clean abstr
     - [Multiple Client Registration](#multiple-client-registration)
   - [API Reference](#api-reference)
     - [Core Types](#core-types)
-      - [`AddAtcRestClient` Extension Methods](#addatcrestclient-extension-methods)
+      - [`AddAtcRestClientCore` Extension Method](#addatcrestclientcore-extension-method)
+      - [`AddAtcRestClient` Extension Methods (Internal)](#addatcrestclient-extension-methods-internal)
       - [`AtcRestClientOptions`](#atcrestclientoptions)
       - [`IHttpMessageFactory`](#ihttpmessagefactory)
       - [`IMessageRequestBuilder`](#imessagerequestbuilder)
@@ -505,10 +506,18 @@ public interface IMessageResponseBuilder
 public class EndpointResponse : IEndpointResponse
 {
     public bool IsSuccess { get; }
+
     public HttpStatusCode StatusCode { get; }
+
     public string Content { get; }
+
     public object? ContentObject { get; }
+
     public IReadOnlyDictionary<string, IEnumerable<string>> Headers { get; }
+
+    protected InvalidOperationException InvalidContentAccessException<TExpected>(
+        HttpStatusCode expectedStatusCode,
+        string propertyName);
 }
 
 // Generic variants available:
@@ -519,32 +528,52 @@ public class EndpointResponse : IEndpointResponse
 #### `BinaryEndpointResponse`
 
 ```csharp
-public class BinaryEndpointResponse
+public class BinaryEndpointResponse : IBinaryEndpointResponse
 {
     public bool IsSuccess { get; }
+
     public bool IsOk { get; }  // True if StatusCode == 200
+
     public HttpStatusCode StatusCode { get; }
+
     public byte[]? Content { get; }
+
     public string? ContentType { get; }
+
     public string? FileName { get; }
+
     public long? ContentLength { get; }
+
+    protected InvalidOperationException InvalidContentAccessException(
+        HttpStatusCode expectedStatusCode,
+        string propertyName);
 }
 ```
 
 #### `StreamBinaryEndpointResponse`
 
 ```csharp
-public class StreamBinaryEndpointResponse : IDisposable
+public class StreamBinaryEndpointResponse : IStreamBinaryEndpointResponse
 {
     public bool IsSuccess { get; }
+
     public bool IsOk { get; }  // True if StatusCode == 200
+
     public HttpStatusCode StatusCode { get; }
+
     public Stream? ContentStream { get; }
+
     public string? ContentType { get; }
+
     public string? FileName { get; }
+
     public long? ContentLength { get; }
 
     public void Dispose();
+
+    protected InvalidOperationException InvalidContentAccessException(
+        HttpStatusCode expectedStatusCode,
+        string propertyName);
 }
 ```
 

--- a/src/Atc.Rest.Client/BinaryEndpointResponse.cs
+++ b/src/Atc.Rest.Client/BinaryEndpointResponse.cs
@@ -4,7 +4,7 @@ namespace Atc.Rest.Client;
 /// Represents a binary file response from an endpoint.
 /// </summary>
 [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Binary content requires array for practical usage.")]
-public sealed class BinaryEndpointResponse : IBinaryEndpointResponse
+public class BinaryEndpointResponse : IBinaryEndpointResponse
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BinaryEndpointResponse"/> class.
@@ -65,4 +65,18 @@ public sealed class BinaryEndpointResponse : IBinaryEndpointResponse
     /// Gets the content length.
     /// </summary>
     public long? ContentLength { get; }
+
+    /// <summary>
+    /// Creates an exception for invalid content access with detailed error information.
+    /// </summary>
+    /// <param name="expectedStatusCode">The expected HTTP status code.</param>
+    /// <param name="propertyName">The name of the property being accessed.</param>
+    /// <returns>An <see cref="InvalidOperationException"/> with detailed error information.</returns>
+    protected InvalidOperationException InvalidContentAccessException(
+        HttpStatusCode expectedStatusCode,
+        string propertyName)
+        => new(
+            $"Cannot access {propertyName}. " +
+            $"Expected status {(int)expectedStatusCode} ({expectedStatusCode}), " +
+            $"but got {(int)StatusCode} ({StatusCode}).");
 }

--- a/src/Atc.Rest.Client/EndpointResponse.cs
+++ b/src/Atc.Rest.Client/EndpointResponse.cs
@@ -39,8 +39,21 @@ public class EndpointResponse : IEndpointResponse
 
     protected TResult CastContent<TResult>()
         where TResult : class
+        => ContentObject as TResult ??
+           throw new InvalidCastException($"ContentObject is not of type {typeof(TResult).Name}");
+
+    protected InvalidOperationException InvalidContentAccessException<TExpected>(
+        HttpStatusCode expectedStatusCode,
+        string propertyName)
+        where TExpected : class
     {
-        return ContentObject as TResult ??
-               throw new InvalidCastException($"ContentObject is not of type {typeof(TResult).Name}");
+        var actualType = ContentObject?.GetType().Name ?? "null";
+        var expectedType = typeof(TExpected).Name;
+
+        return new InvalidOperationException(
+            $"Cannot access {propertyName}. " +
+            $"Expected status {(int)expectedStatusCode} ({expectedStatusCode}) with {expectedType} content, " +
+            $"but got {(int)StatusCode} ({StatusCode}) with {actualType} content. " +
+            $"Response: {Content}");
     }
 }

--- a/src/Atc.Rest.Client/StreamBinaryEndpointResponse.cs
+++ b/src/Atc.Rest.Client/StreamBinaryEndpointResponse.cs
@@ -3,7 +3,7 @@ namespace Atc.Rest.Client;
 /// <summary>
 /// Represents a streaming binary response from an endpoint.
 /// </summary>
-public sealed class StreamBinaryEndpointResponse : IStreamBinaryEndpointResponse
+public class StreamBinaryEndpointResponse : IStreamBinaryEndpointResponse
 {
     private bool disposed;
 
@@ -77,10 +77,24 @@ public sealed class StreamBinaryEndpointResponse : IStreamBinaryEndpointResponse
     }
 
     /// <summary>
+    /// Creates an exception for invalid content access with detailed error information.
+    /// </summary>
+    /// <param name="expectedStatusCode">The expected HTTP status code.</param>
+    /// <param name="propertyName">The name of the property being accessed.</param>
+    /// <returns>An <see cref="InvalidOperationException"/> with detailed error information.</returns>
+    protected InvalidOperationException InvalidContentAccessException(
+        HttpStatusCode expectedStatusCode,
+        string propertyName)
+        => new(
+            $"Cannot access {propertyName}. " +
+            $"Expected status {(int)expectedStatusCode} ({expectedStatusCode}), " +
+            $"but got {(int)StatusCode} ({StatusCode}).");
+
+    /// <summary>
     /// Disposes managed resources.
     /// </summary>
     /// <param name="disposing">Whether to dispose managed resources.</param>
-    private void Dispose(bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (disposed)
         {

--- a/test/Atc.Rest.Client.Tests/BinaryEndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/BinaryEndpointResponseTests.cs
@@ -3,6 +3,65 @@ namespace Atc.Rest.Client.Tests;
 public sealed class BinaryEndpointResponseTests
 {
     [Fact]
+    public void InvalidContentAccessException_ContainsExpectedStatusCode()
+    {
+        // Arrange
+        var sut = new TestableBinaryEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            content: null,
+            contentType: null,
+            fileName: null,
+            contentLength: null);
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException(HttpStatusCode.OK, "OKContent");
+
+        // Assert
+        exception.Message.Should().Contain("200");
+        exception.Message.Should().Contain("OK");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsActualStatusCode()
+    {
+        // Arrange
+        var sut = new TestableBinaryEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            content: null,
+            contentType: null,
+            fileName: null,
+            contentLength: null);
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException(HttpStatusCode.OK, "OKContent");
+
+        // Assert
+        exception.Message.Should().Contain("409");
+        exception.Message.Should().Contain("Conflict");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsPropertyName()
+    {
+        // Arrange
+        var sut = new TestableBinaryEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            content: null,
+            contentType: null,
+            fileName: null,
+            contentLength: null);
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException(HttpStatusCode.OK, "OKContent");
+
+        // Assert
+        exception.Message.Should().Contain("OKContent");
+    }
+
+    [Fact]
     public void Constructor_SetsAllProperties()
     {
         // Arrange
@@ -61,5 +120,24 @@ public sealed class BinaryEndpointResponseTests
         sut.ContentType.Should().BeNull();
         sut.FileName.Should().BeNull();
         sut.ContentLength.Should().BeNull();
+    }
+
+    private sealed class TestableBinaryEndpointResponse : BinaryEndpointResponse
+    {
+        public TestableBinaryEndpointResponse(
+            bool isSuccess,
+            HttpStatusCode statusCode,
+            byte[]? content,
+            string? contentType,
+            string? fileName,
+            long? contentLength)
+            : base(isSuccess, statusCode, content, contentType, fileName, contentLength)
+        {
+        }
+
+        public InvalidOperationException GetInvalidContentAccessException(
+            HttpStatusCode expectedStatusCode,
+            string propertyName)
+            => InvalidContentAccessException(expectedStatusCode, propertyName);
     }
 }

--- a/test/Atc.Rest.Client.Tests/EndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/EndpointResponseTests.cs
@@ -2,6 +2,130 @@ namespace Atc.Rest.Client.Tests;
 
 public class EndpointResponseTests
 {
+    [Fact]
+    public void InvalidContentAccessException_ContainsExpectedStatusCode()
+    {
+        // Arrange
+        var sut = new TestableEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            "{\"error\":\"conflict\"}",
+            new BadResponse(),
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException<SuccessResponse>(
+            HttpStatusCode.Created,
+            "CreatedContent");
+
+        // Assert
+        exception.Message.Should().Contain("201");
+        exception.Message.Should().Contain("Created");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsActualStatusCode()
+    {
+        // Arrange
+        var sut = new TestableEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            "{\"error\":\"conflict\"}",
+            new BadResponse(),
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException<SuccessResponse>(
+            HttpStatusCode.Created,
+            "CreatedContent");
+
+        // Assert
+        exception.Message.Should().Contain("409");
+        exception.Message.Should().Contain("Conflict");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsExpectedAndActualTypes()
+    {
+        // Arrange
+        var sut = new TestableEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            "{\"error\":\"conflict\"}",
+            new BadResponse(),
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException<SuccessResponse>(
+            HttpStatusCode.Created,
+            "CreatedContent");
+
+        // Assert
+        exception.Message.Should().Contain("SuccessResponse");
+        exception.Message.Should().Contain("BadResponse");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsPropertyName()
+    {
+        // Arrange
+        var sut = new TestableEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            "{\"error\":\"conflict\"}",
+            new BadResponse(),
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException<SuccessResponse>(
+            HttpStatusCode.Created,
+            "CreatedContent");
+
+        // Assert
+        exception.Message.Should().Contain("CreatedContent");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsResponseContent()
+    {
+        // Arrange
+        var responseContent = "{\"error\":\"conflict\"}";
+        var sut = new TestableEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            responseContent,
+            new BadResponse(),
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException<SuccessResponse>(
+            HttpStatusCode.Created,
+            "CreatedContent");
+
+        // Assert
+        exception.Message.Should().Contain(responseContent);
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_WithNullContentObject_ContainsNullType()
+    {
+        // Arrange
+        var sut = new TestableEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            string.Empty,
+            null,
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException<SuccessResponse>(
+            HttpStatusCode.Created,
+            "CreatedContent");
+
+        // Assert
+        exception.Message.Should().Contain("null");
+    }
+
     [Theory, AutoNSubstituteData]
     public void SuccessContent_Returns_Response_Upon_Success(
         SuccessResponse contentObject,
@@ -70,5 +194,24 @@ public class EndpointResponseTests
             .ErrorContent
             .Should()
             .Be(contentObject);
+    }
+
+    private sealed class TestableEndpointResponse : EndpointResponse
+    {
+        public TestableEndpointResponse(
+            bool isSuccess,
+            HttpStatusCode statusCode,
+            string content,
+            object? contentObject,
+            IReadOnlyDictionary<string, IEnumerable<string>> headers)
+            : base(isSuccess, statusCode, content, contentObject, headers)
+        {
+        }
+
+        public InvalidOperationException GetInvalidContentAccessException<TExpected>(
+            HttpStatusCode expectedStatusCode,
+            string propertyName)
+            where TExpected : class
+            => InvalidContentAccessException<TExpected>(expectedStatusCode, propertyName);
     }
 }

--- a/test/Atc.Rest.Client.Tests/StreamBinaryEndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/StreamBinaryEndpointResponseTests.cs
@@ -3,6 +3,65 @@ namespace Atc.Rest.Client.Tests;
 public sealed class StreamBinaryEndpointResponseTests
 {
     [Fact]
+    public void InvalidContentAccessException_ContainsExpectedStatusCode()
+    {
+        // Arrange
+        using var sut = new TestableStreamBinaryEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            contentStream: null,
+            contentType: null,
+            fileName: null,
+            contentLength: null);
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException(HttpStatusCode.OK, "OKContent");
+
+        // Assert
+        exception.Message.Should().Contain("200");
+        exception.Message.Should().Contain("OK");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsActualStatusCode()
+    {
+        // Arrange
+        using var sut = new TestableStreamBinaryEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            contentStream: null,
+            contentType: null,
+            fileName: null,
+            contentLength: null);
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException(HttpStatusCode.OK, "OKContent");
+
+        // Assert
+        exception.Message.Should().Contain("409");
+        exception.Message.Should().Contain("Conflict");
+    }
+
+    [Fact]
+    public void InvalidContentAccessException_ContainsPropertyName()
+    {
+        // Arrange
+        using var sut = new TestableStreamBinaryEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            contentStream: null,
+            contentType: null,
+            fileName: null,
+            contentLength: null);
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException(HttpStatusCode.OK, "OKContent");
+
+        // Assert
+        exception.Message.Should().Contain("OKContent");
+    }
+
+    [Fact]
     public void Constructor_SetsAllProperties()
     {
         // Arrange
@@ -66,5 +125,24 @@ public sealed class StreamBinaryEndpointResponseTests
 
         // Assert - first dispose already happens via using, this is the second
         act.Should().NotThrow();
+    }
+
+    private sealed class TestableStreamBinaryEndpointResponse : StreamBinaryEndpointResponse
+    {
+        public TestableStreamBinaryEndpointResponse(
+            bool isSuccess,
+            HttpStatusCode statusCode,
+            Stream? contentStream,
+            string? contentType,
+            string? fileName,
+            long? contentLength)
+            : base(isSuccess, statusCode, contentStream, contentType, fileName, contentLength)
+        {
+        }
+
+        public InvalidOperationException GetInvalidContentAccessException(
+            HttpStatusCode expectedStatusCode,
+            string propertyName)
+            => InvalidContentAccessException(expectedStatusCode, propertyName);
     }
 }


### PR DESCRIPTION
feat: Add InvalidContentAccessException helpers and make response classes inheritable

- Make BinaryEndpointResponse and StreamBinaryEndpointResponse non-sealed for inheritance
- Add protected InvalidContentAccessException<T>() helper to EndpointResponse
- Add protected InvalidContentAccessException() helper to BinaryEndpointResponse
- Add protected InvalidContentAccessException() helper to StreamBinaryEndpointResponse
- Make Dispose(bool) protected virtual in StreamBinaryEndpointResponse
- Add comprehensive tests for the new exception helpers
- Update README documentation

This enables cleaner code generation in `atc-rest-api-source-generator` and `atc-rest-api-generator`  by providing rich exception context when content properties are accessed without status checking.