### PR TITLE
Remove Microsoft.AspNetCore.Http dependency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -579,6 +579,8 @@ dotnet_diagnostic.S6964.severity = none             # Value type property used a
 # Custom - Code Analyzers Rules
 ##########################################
 
+dotnet_diagnostic.ATC210.max_line_length = 100
+
 dotnet_diagnostic.CA1014.severity = none    #
 dotnet_diagnostic.CA1859.severity = none    #
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,9 +39,10 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
+    <PackageReference Include="Atc.Analyzer " Version="0.1.22" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.296" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.7" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793" PrivateAssets="All" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="Atc.Analyzer " Version="0.1.22" PrivateAssets="All" />
+    <PackageReference Include="Atc.Analyzer" Version="0.1.22" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.7" PrivateAssets="All" />

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A lightweight and flexible REST client library for .NET, providing a clean abstr
     - [📤 POST Request with Body](#-post-request-with-body)
     - [🔗 Using Path and Query Parameters](#-using-path-and-query-parameters)
     - [📎 File Upload (Multipart Form Data)](#-file-upload-multipart-form-data)
+    - [📁 File Upload with IFileContent](#-file-upload-with-ifilecontent)
     - [📤 Binary Upload (Raw Stream)](#-binary-upload-raw-stream)
     - [💾 File Download (Binary Response)](#-file-download-binary-response)
     - [🌊 Streaming Responses (IAsyncEnumerable)](#-streaming-responses-iasyncenumerable)
@@ -269,6 +270,49 @@ requestBuilder.WithFiles(files);
 
 using var request = requestBuilder.Build(HttpMethod.Post);
 ```
+
+### 📁 File Upload with IFileContent
+
+For file uploads via `WithBody()`, implement the `IFileContent` interface:
+
+```csharp
+using Atc.Rest.Client;
+
+public class MyFile : IFileContent
+{
+    public string FileName { get; init; }
+    public string? ContentType { get; init; }
+    public Stream OpenReadStream() => File.OpenRead(path);
+}
+
+var requestBuilder = messageFactory.FromTemplate("/api/files/upload");
+requestBuilder.WithBody(new MyFile { FileName = "report.pdf", ContentType = "application/pdf" });
+
+using var request = requestBuilder.Build(HttpMethod.Post);
+using var response = await client.SendAsync(request, cancellationToken);
+```
+
+`WithBody()` also accepts `List<IFileContent>` for multi-file uploads.
+
+> **Platform compatibility:** `WithBody()` automatically detects file-like objects that have
+> a `FileName` (or `Name`) property and an `OpenReadStream()` method. This means ASP.NET Core
+> `IFormFile` and Blazor `IBrowserFile` objects work without any additional packages or adapters:
+>
+> ```csharp
+> // ASP.NET Core controller - works automatically
+> public async Task<IActionResult> Upload(IFormFile file)
+> {
+>     requestBuilder.WithBody(file);
+> }
+>
+> // Blazor WASM component - works automatically
+> private async Task OnFileSelected(InputFileChangeEventArgs e)
+> {
+>     requestBuilder.WithBody(e.File);
+> }
+> ```
+>
+> For compile-time type safety, implement `IFileContent` explicitly.
 
 ### 📤 Binary Upload (Raw Stream)
 
@@ -551,6 +595,21 @@ public interface IMessageRequestBuilder
     IMessageRequestBuilder WithFormField(string name, string value);
 }
 ```
+
+> **`IFileContent` interface:**
+>
+> ```csharp
+> public interface IFileContent
+> {
+>     string FileName { get; }
+>     string? ContentType { get; }
+>     Stream OpenReadStream();
+> }
+> ```
+>
+> Used with `WithBody<TBody>()` for file uploads. Objects passed to `WithBody()` that have
+> a `FileName`/`Name` property and an `OpenReadStream()` method are automatically detected
+> and uploaded as multipart form data — no explicit `IFileContent` implementation required.
 
 #### `IMessageResponseBuilder`
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ public class MyFile : IFileContent
 {
     public string FileName { get; init; }
     public string? ContentType { get; init; }
-    public Stream OpenReadStream() => File.OpenRead(path);
+    public Stream OpenReadStream() => File.OpenRead(FileName);
 }
 
 var requestBuilder = messageFactory.FromTemplate("/api/files/upload");

--- a/src/Atc.Rest.Client/Atc.Rest.Client.csproj
+++ b/src/Atc.Rest.Client/Atc.Rest.Client.csproj
@@ -13,11 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.2" />
-    <PackageReference Include="System.Text.Json" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest.Client/Atc.Rest.Client.csproj
+++ b/src/Atc.Rest.Client/Atc.Rest.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.2" />
     <PackageReference Include="System.Text.Json" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />

--- a/src/Atc.Rest.Client/Builder/HttpMessageFactory.cs
+++ b/src/Atc.Rest.Client/Builder/HttpMessageFactory.cs
@@ -4,20 +4,17 @@ internal class HttpMessageFactory : IHttpMessageFactory
 {
     private readonly IContractSerializer serializer;
 
-    public HttpMessageFactory(
-        IContractSerializer serializer)
+    public HttpMessageFactory(IContractSerializer serializer)
     {
         this.serializer = serializer;
     }
 
-    public IMessageRequestBuilder FromTemplate(
-        string pathTemplate)
+    public IMessageRequestBuilder FromTemplate(string pathTemplate)
         => new MessageRequestBuilder(
             pathTemplate,
             serializer);
 
-    public IMessageResponseBuilder FromResponse(
-        HttpResponseMessage? response)
+    public IMessageResponseBuilder FromResponse(HttpResponseMessage? response)
         => new MessageResponseBuilder(
             response,
             serializer);

--- a/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
+++ b/src/Atc.Rest.Client/Builder/IHttpMessageFactory.cs
@@ -17,14 +17,12 @@ public interface IHttpMessageFactory
     /// that will be replaced with real values passed to the <see cref="IMessageRequestBuilder.WithPathParameter(string, object?)"/>
     /// method.</param>
     /// <returns>A new <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder FromTemplate(
-        string pathTemplate);
+    IMessageRequestBuilder FromTemplate(string pathTemplate);
 
     /// <summary>
     /// Creates a message response builder from an HTTP response message.
     /// </summary>
     /// <param name="response">The HTTP response message to process. Can be null.</param>
     /// <returns>A new <see cref="IMessageResponseBuilder"/>.</returns>
-    IMessageResponseBuilder FromResponse(
-        HttpResponseMessage? response);
+    IMessageResponseBuilder FromResponse(HttpResponseMessage? response);
 }

--- a/src/Atc.Rest.Client/Builder/IMessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/IMessageRequestBuilder.cs
@@ -17,7 +17,9 @@ public interface IMessageRequestBuilder
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="value"/> is null or whitespace.</exception>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithPathParameter(string name, object? value);
+    IMessageRequestBuilder WithPathParameter(
+        string name,
+        object? value);
 
     /// <summary>
     /// Adds a value to a header parameter in the headers.
@@ -26,7 +28,9 @@ public interface IMessageRequestBuilder
     /// <param name="value">Value to use as the header parameter.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithHeaderParameter(string name, object? value);
+    IMessageRequestBuilder WithHeaderParameter(
+        string name,
+        object? value);
 
     /// <summary>
     /// Adds a query parameter to the created request URL.
@@ -38,7 +42,9 @@ public interface IMessageRequestBuilder
     /// <param name="value">Value of the query parameter.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithQueryParameter(string name, string? value);
+    IMessageRequestBuilder WithQueryParameter(
+        string name,
+        string? value);
 
     /// <summary>
     /// Adds a query parameter with multiple values to the created request URL.
@@ -51,7 +57,9 @@ public interface IMessageRequestBuilder
     /// <param name="values">Collection of values for the query parameter.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithQueryParameter(string name, IEnumerable? values);
+    IMessageRequestBuilder WithQueryParameter(
+        string name,
+        IEnumerable? values);
 
     /// <summary>
     /// Adds a query parameter to the created request URL.
@@ -64,7 +72,9 @@ public interface IMessageRequestBuilder
     /// <param name="value">Value of the query parameter.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is null or whitespace.</exception>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithQueryParameter(string name, object? value);
+    IMessageRequestBuilder WithQueryParameter(
+        string name,
+        object? value);
 
     /// <summary>
     /// Adds the body of the request.
@@ -87,7 +97,9 @@ public interface IMessageRequestBuilder
     /// <param name="stream">The stream to send as the request body.</param>
     /// <param name="contentType">Optional content type. Defaults to application/octet-stream.</param>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithBinaryBody(Stream stream, string? contentType = null);
+    IMessageRequestBuilder WithBinaryBody(
+        Stream stream,
+        string? contentType = null);
 
     /// <summary>
     /// Builds a <see cref="HttpRequestMessage"/> with the added content.
@@ -102,7 +114,8 @@ public interface IMessageRequestBuilder
     /// </summary>
     /// <param name="completionOption">The HTTP completion option.</param>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithHttpCompletionOption(HttpCompletionOption completionOption);
+    IMessageRequestBuilder WithHttpCompletionOption(
+        HttpCompletionOption completionOption);
 
     /// <summary>
     /// Gets the HTTP completion option set for this request.
@@ -117,14 +130,19 @@ public interface IMessageRequestBuilder
     /// <param name="fileName">The file name.</param>
     /// <param name="contentType">Optional content type. Defaults to application/octet-stream.</param>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithFile(Stream stream, string name, string fileName, string? contentType = null);
+    IMessageRequestBuilder WithFile(
+        Stream stream,
+        string name,
+        string fileName,
+        string? contentType = null);
 
     /// <summary>
     /// Adds multiple files to the multipart form data content.
     /// </summary>
     /// <param name="files">Collection of files with Stream, Name, FileName, and optional ContentType.</param>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithFiles(IEnumerable<(Stream Stream, string Name, string FileName, string? ContentType)> files);
+    IMessageRequestBuilder WithFiles(
+        IEnumerable<(Stream Stream, string Name, string FileName, string? ContentType)> files);
 
     /// <summary>
     /// Adds a form field to the multipart form data content.
@@ -132,5 +150,7 @@ public interface IMessageRequestBuilder
     /// <param name="name">The form field name.</param>
     /// <param name="value">The form field value.</param>
     /// <returns>The <see cref="IMessageRequestBuilder"/>.</returns>
-    IMessageRequestBuilder WithFormField(string name, string value);
+    IMessageRequestBuilder WithFormField(
+        string name,
+        string value);
 }

--- a/src/Atc.Rest.Client/Builder/IMessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/IMessageResponseBuilder.cs
@@ -10,8 +10,7 @@ public interface IMessageResponseBuilder
     /// </summary>
     /// <param name="statusCode">The HTTP status code to treat as success.</param>
     /// <returns>The <see cref="IMessageResponseBuilder"/>.</returns>
-    IMessageResponseBuilder AddSuccessResponse(
-        HttpStatusCode statusCode);
+    IMessageResponseBuilder AddSuccessResponse(HttpStatusCode statusCode);
 
     /// <summary>
     /// Registers a status code as a success response with typed content deserialization.
@@ -27,8 +26,7 @@ public interface IMessageResponseBuilder
     /// </summary>
     /// <param name="statusCode">The HTTP status code to treat as error.</param>
     /// <returns>The <see cref="IMessageResponseBuilder"/>.</returns>
-    IMessageResponseBuilder AddErrorResponse(
-        HttpStatusCode statusCode);
+    IMessageResponseBuilder AddErrorResponse(HttpStatusCode statusCode);
 
     /// <summary>
     /// Registers a status code as an error response with typed content deserialization.
@@ -57,8 +55,7 @@ public interface IMessageResponseBuilder
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An <see cref="EndpointResponse{TSuccess}"/> with the typed success content.</returns>
     Task<EndpointResponse<TSuccessContent>>
-        BuildResponseAsync<TSuccessContent>(
-            CancellationToken cancellationToken)
+        BuildResponseAsync<TSuccessContent>(CancellationToken cancellationToken)
         where TSuccessContent : class;
 
     /// <summary>

--- a/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
@@ -147,8 +147,7 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
         return formDataContent;
     }
 
-    public IMessageRequestBuilder WithBody<TBody>(
-        TBody body)
+    public IMessageRequestBuilder WithBody<TBody>(TBody body)
     {
         if (body is null)
         {
@@ -322,16 +321,16 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
     /// <summary>
     /// Gets the EnumMemberAttribute value for an enum member, using a cache to avoid repeated reflection.
     /// </summary>
-    private static string? GetEnumMemberValue(Type enumType, string memberName)
-    {
-        return EnumMemberCache.GetOrAdd((enumType, memberName), key =>
+    private static string? GetEnumMemberValue(
+        Type enumType,
+        string memberName)
+        => EnumMemberCache.GetOrAdd((enumType, memberName), key =>
             key.EnumType
                 .GetTypeInfo()
                 .DeclaredMembers
                 .FirstOrDefault(x => x.Name == key.MemberName)
                 ?.GetCustomAttribute<EnumMemberAttribute>(inherit: false)
                 ?.Value);
-    }
 
     private Uri BuildRequestUri()
     {
@@ -362,7 +361,8 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
     /// These values are emitted as-is without additional URI encoding.
     /// Regular keys have their values URI-encoded to ensure proper escaping.
     /// </remarks>
-    private static string BuildQueryKeyEqualValue(KeyValuePair<string, string> pair)
+    private static string BuildQueryKeyEqualValue(
+        KeyValuePair<string, string> pair)
         => pair.Key.StartsWith("#", StringComparison.Ordinal)
             ? $"{pair.Key.Replace("#", string.Empty)}={pair.Value}"
             : $"{pair.Key}={Uri.EscapeDataString(pair.Value)}";

--- a/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
@@ -16,7 +16,7 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
     private readonly Dictionary<string, string> formFields;
     private readonly List<(Stream Stream, string Name, string FileName, string? ContentType)> streamFiles;
     private string? content;
-    private List<IFormFile>? contentFormFiles;
+    private List<IFileContent>? contentFormFiles;
     private (Stream Stream, string ContentType)? binaryContent;
 
     public MessageRequestBuilder(
@@ -123,16 +123,22 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
     {
         var formDataContent = new MultipartFormDataContent();
 
-        foreach (var formFile in contentFormFiles!)
+        foreach (var fileContent in contentFormFiles!)
         {
             byte[] bytes;
-            using (var binaryReader = new BinaryReader(formFile.OpenReadStream()))
+            using (var stream = fileContent.OpenReadStream())
+            using (var binaryReader = new BinaryReader(stream))
             {
-                bytes = binaryReader.ReadBytes((int)formFile.OpenReadStream().Length);
+                bytes = binaryReader.ReadBytes((int)stream.Length);
             }
 
             var bytesContent = new ByteArrayContent(bytes);
-            formDataContent.Add(bytesContent, "Request", formFile.FileName);
+            if (fileContent.ContentType is not null)
+            {
+                bytesContent.Headers.ContentType = MediaTypeHeaderValue.Parse(fileContent.ContentType);
+            }
+
+            formDataContent.Add(bytesContent, "Request", fileContent.FileName);
         }
 
         message.Headers.Remove("accept");
@@ -151,18 +157,26 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
 
         switch (body)
         {
-            case IFormFile formFile:
-                contentFormFiles = new List<IFormFile>
-                {
-                    formFile,
-                };
+            case IFileContent fileContent:
+                contentFormFiles = [fileContent];
                 break;
-            case List<IFormFile> formFiles:
-                contentFormFiles = new List<IFormFile>();
-                contentFormFiles.AddRange(formFiles);
+            case List<IFileContent> fileContents:
+                contentFormFiles = new List<IFileContent>(fileContents);
                 break;
             default:
-                content = serializer.Serialize(body);
+                if (TryWrapAsFileContent(body, out var wrapped))
+                {
+                    contentFormFiles = [wrapped];
+                }
+                else if (TryWrapAsFileContentList(body, out var wrappedList))
+                {
+                    contentFormFiles = wrappedList;
+                }
+                else
+                {
+                    content = serializer.Serialize(body);
+                }
+
                 break;
         }
 
@@ -417,5 +431,96 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
     {
         HttpCompletionOption = completionOption;
         return this;
+    }
+
+    private static bool TryWrapAsFileContent(
+        object obj,
+        [NotNullWhen(true)] out IFileContent? fileContent)
+    {
+        fileContent = null;
+
+        var type = obj.GetType();
+
+        var fileNameProp = type.GetProperty("FileName", typeof(string))
+                           ?? type.GetProperty("Name", typeof(string));
+        if (fileNameProp is null)
+        {
+            return false;
+        }
+
+        var openReadStreamMethod = FindOpenReadStreamMethod(type);
+        if (openReadStreamMethod is null)
+        {
+            return false;
+        }
+
+        var contentTypeProp = type.GetProperty("ContentType", typeof(string));
+
+        fileContent = new ReflectedFileContent(obj, fileNameProp, contentTypeProp, openReadStreamMethod);
+        return true;
+    }
+
+    private static bool TryWrapAsFileContentList(
+        object obj,
+        [NotNullWhen(true)] out List<IFileContent>? fileContents)
+    {
+        fileContents = null;
+
+        if (obj is not IEnumerable enumerable)
+        {
+            return false;
+        }
+
+        List<IFileContent>? result = null;
+        foreach (var item in enumerable)
+        {
+            if (item is null || !TryWrapAsFileContent(item, out var wrapped))
+            {
+                return false;
+            }
+
+            result ??= [];
+            result.Add(wrapped);
+        }
+
+        if (result is null or { Count: 0 })
+        {
+            return false;
+        }
+
+        fileContents = result;
+        return true;
+    }
+
+    private static MethodInfo? FindOpenReadStreamMethod(Type type)
+    {
+        // Prefer parameterless OpenReadStream() (matches IFormFile)
+        var method = type.GetMethod("OpenReadStream", Type.EmptyTypes);
+        if (method is not null && typeof(Stream).IsAssignableFrom(method.ReturnType))
+        {
+            return method;
+        }
+
+        // Fall back to OpenReadStream where all parameters are optional (matches IBrowserFile)
+        foreach (var candidate in type.GetMethods())
+        {
+            if (!string.Equals(candidate.Name, "OpenReadStream", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!typeof(Stream).IsAssignableFrom(candidate.ReturnType))
+            {
+                continue;
+            }
+
+            var parameters = candidate.GetParameters();
+            if (parameters.Length > 0 && parameters.All(p => p.IsOptional))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageRequestBuilder.cs
@@ -127,9 +127,10 @@ internal class MessageRequestBuilder : IMessageRequestBuilder
         {
             byte[] bytes;
             using (var stream = fileContent.OpenReadStream())
-            using (var binaryReader = new BinaryReader(stream))
             {
-                bytes = binaryReader.ReadBytes((int)stream.Length);
+                using var memoryStream = new MemoryStream();
+                stream.CopyTo(memoryStream);
+                bytes = memoryStream.ToArray();
             }
 
             var bytesContent = new ByteArrayContent(bytes);

--- a/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
@@ -25,19 +25,16 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
         responseCodes = [];
     }
 
-    private delegate object? ContentSerializerDelegate(
-        string content);
+    private delegate object? ContentSerializerDelegate(string content);
 
-    public IMessageResponseBuilder AddErrorResponse(
-        HttpStatusCode statusCode)
+    public IMessageResponseBuilder AddErrorResponse(HttpStatusCode statusCode)
         => AddEmptyResponse(statusCode, isSuccess: false);
 
     public IMessageResponseBuilder AddErrorResponse<TResponseContent>(
         HttpStatusCode statusCode)
         => AddTypedResponse<TResponseContent>(statusCode, isSuccess: false);
 
-    public IMessageResponseBuilder AddSuccessResponse(
-        HttpStatusCode statusCode)
+    public IMessageResponseBuilder AddSuccessResponse(HttpStatusCode statusCode)
         => AddEmptyResponse(statusCode, isSuccess: true);
 
     public IMessageResponseBuilder AddSuccessResponse<TResponseContent>(
@@ -304,8 +301,7 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
         return headers;
     }
 
-    private bool IsSuccessStatus(
-        HttpResponseMessage responseMessage)
+    private bool IsSuccessStatus(HttpResponseMessage responseMessage)
         => responseCodes.TryGetValue(responseMessage.StatusCode, out var isSuccess)
             ? isSuccess
             : responseMessage.IsSuccessStatusCode;
@@ -327,7 +323,8 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
     }
 
     private IMessageResponseBuilder AddTypedResponse<T>(
-        HttpStatusCode statusCode, bool isSuccess)
+        HttpStatusCode statusCode,
+        bool isSuccess)
     {
         responseSerializers[statusCode] = (
             content => string.IsNullOrWhiteSpace(content)

--- a/src/Atc.Rest.Client/Builder/ReflectedFileContent.cs
+++ b/src/Atc.Rest.Client/Builder/ReflectedFileContent.cs
@@ -1,0 +1,35 @@
+namespace Atc.Rest.Client.Builder;
+
+internal sealed class ReflectedFileContent : IFileContent
+{
+    private readonly object target;
+    private readonly PropertyInfo fileNameProp;
+    private readonly PropertyInfo? contentTypeProp;
+    private readonly MethodInfo openReadStreamMethod;
+
+    public ReflectedFileContent(
+        object target,
+        PropertyInfo fileNameProp,
+        PropertyInfo? contentTypeProp,
+        MethodInfo openReadStreamMethod)
+    {
+        this.target = target;
+        this.fileNameProp = fileNameProp;
+        this.contentTypeProp = contentTypeProp;
+        this.openReadStreamMethod = openReadStreamMethod;
+    }
+
+    public string FileName => (string)fileNameProp.GetValue(target)!;
+
+    public string? ContentType => (string?)contentTypeProp?.GetValue(target);
+
+    public Stream OpenReadStream()
+    {
+        var parameters = openReadStreamMethod.GetParameters();
+        var args = parameters.Length > 0
+            ? parameters.Select(p => p.DefaultValue).ToArray()
+            : null;
+
+        return (Stream)openReadStreamMethod.Invoke(target, args)!;
+    }
+}

--- a/src/Atc.Rest.Client/Builder/ReflectedFileContent.cs
+++ b/src/Atc.Rest.Client/Builder/ReflectedFileContent.cs
@@ -26,9 +26,30 @@ internal sealed class ReflectedFileContent : IFileContent
     public Stream OpenReadStream()
     {
         var parameters = openReadStreamMethod.GetParameters();
-        var args = parameters.Length > 0
-            ? parameters.Select(p => p.DefaultValue).ToArray()
-            : null;
+        object?[]? args = null;
+
+        if (parameters.Length > 0)
+        {
+            args = new object?[parameters.Length];
+
+            if (parameters.Length == 2 &&
+                parameters[0].ParameterType == typeof(long) &&
+                parameters[1].ParameterType == typeof(CancellationToken))
+            {
+                args[0] = long.MaxValue;
+                args[1] = CancellationToken.None;
+            }
+            else
+            {
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var defaultValue = parameters[i].DefaultValue;
+                    args[i] = ReferenceEquals(defaultValue, Missing.Value)
+                        ? Type.Missing
+                        : defaultValue;
+                }
+            }
+        }
 
         return (Stream)openReadStreamMethod.Invoke(target, args)!;
     }

--- a/src/Atc.Rest.Client/GlobalUsings.cs
+++ b/src/Atc.Rest.Client/GlobalUsings.cs
@@ -12,6 +12,5 @@ global using System.Text.Json;
 global using System.Text.Json.Serialization;
 global using Atc.Rest.Client.Builder;
 global using Atc.Rest.Client.Serialization;
-global using Microsoft.AspNetCore.Http;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Atc.Rest.Client/IFileContent.cs
+++ b/src/Atc.Rest.Client/IFileContent.cs
@@ -1,0 +1,13 @@
+namespace Atc.Rest.Client;
+
+/// <summary>
+/// Represents a file to be uploaded via <see cref="Builder.IMessageRequestBuilder.WithBody{TBody}"/>.
+/// </summary>
+public interface IFileContent
+{
+    string FileName { get; }
+
+    string? ContentType { get; }
+
+    Stream OpenReadStream();
+}

--- a/src/Atc.Rest.Client/RestClientDeserializationException.cs
+++ b/src/Atc.Rest.Client/RestClientDeserializationException.cs
@@ -26,7 +26,9 @@ public class RestClientDeserializationException : Exception
     /// </summary>
     /// <param name="message">The error message.</param>
     /// <param name="innerException">The inner exception that caused deserialization to fail.</param>
-    public RestClientDeserializationException(string message, Exception innerException)
+    public RestClientDeserializationException(
+        string message,
+        Exception innerException)
         : base(message, innerException)
     {
     }

--- a/src/Atc.Rest.Client/Serialization/DefaultJsonContractSerializer.cs
+++ b/src/Atc.Rest.Client/Serialization/DefaultJsonContractSerializer.cs
@@ -33,8 +33,7 @@ public class DefaultJsonContractSerializer : IContractSerializer
     /// </summary>
     /// <param name="value">The object to serialize.</param>
     /// <returns>A JSON string representation of the object.</returns>
-    public string Serialize(
-        object value)
+    public string Serialize(object value)
         => JsonSerializer.Serialize(
             value,
             options);
@@ -45,8 +44,7 @@ public class DefaultJsonContractSerializer : IContractSerializer
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <param name="json">The JSON string to deserialize.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
-    public T? Deserialize<T>(
-        string json)
+    public T? Deserialize<T>(string json)
         => JsonSerializer.Deserialize<T>(
             json,
             options);
@@ -57,8 +55,7 @@ public class DefaultJsonContractSerializer : IContractSerializer
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <param name="utf8Json">The UTF-8 encoded JSON byte array.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
-    public T? Deserialize<T>(
-        byte[] utf8Json)
+    public T? Deserialize<T>(byte[] utf8Json)
         => JsonSerializer.Deserialize<T>(
             utf8Json,
             options);
@@ -84,7 +81,8 @@ public class DefaultJsonContractSerializer : IContractSerializer
     /// <param name="returnType">The type to deserialize to.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
     public object? Deserialize(
-        byte[] utf8Json, Type returnType)
+        byte[] utf8Json,
+        Type returnType)
         => JsonSerializer.Deserialize(
             utf8Json,
             returnType,

--- a/src/Atc.Rest.Client/Serialization/IContractSerializer.cs
+++ b/src/Atc.Rest.Client/Serialization/IContractSerializer.cs
@@ -10,8 +10,7 @@ public interface IContractSerializer
     /// </summary>
     /// <param name="value">The object to serialize.</param>
     /// <returns>A string representation of the object.</returns>
-    string Serialize(
-        object value);
+    string Serialize(object value);
 
     /// <summary>
     /// Deserializes a string to the specified type.
@@ -19,8 +18,7 @@ public interface IContractSerializer
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <param name="json">The string to deserialize.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
-    T? Deserialize<T>(
-        string json);
+    T? Deserialize<T>(string json);
 
     /// <summary>
     /// Deserializes a UTF-8 encoded byte array to the specified type.
@@ -28,8 +26,7 @@ public interface IContractSerializer
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <param name="utf8Json">The UTF-8 encoded byte array to deserialize.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
-    T? Deserialize<T>(
-        byte[] utf8Json);
+    T? Deserialize<T>(byte[] utf8Json);
 
     /// <summary>
     /// Deserializes a string to the specified type.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,7 +53,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/Atc.Rest.Client.Tests/Atc.Rest.Client.Tests.csproj
+++ b/test/Atc.Rest.Client.Tests/Atc.Rest.Client.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Atc.Rest.Client.Tests/BinaryEndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/BinaryEndpointResponseTests.cs
@@ -146,23 +146,4 @@ public sealed class BinaryEndpointResponseTests
         sut.IsSuccess.Should().BeTrue();
         sut.ErrorContent.Should().BeNull();
     }
-
-    private sealed class TestableBinaryEndpointResponse : BinaryEndpointResponse
-    {
-        public TestableBinaryEndpointResponse(
-            bool isSuccess,
-            HttpStatusCode statusCode,
-            byte[]? content,
-            string? contentType,
-            string? fileName,
-            long? contentLength)
-            : base(isSuccess, statusCode, content, contentType, fileName, contentLength)
-        {
-        }
-
-        public InvalidOperationException GetInvalidContentAccessException(
-            HttpStatusCode expectedStatusCode,
-            string propertyName)
-            => InvalidContentAccessException(expectedStatusCode, propertyName);
-    }
 }

--- a/test/Atc.Rest.Client.Tests/Builder/HttpMessageFactoryTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/HttpMessageFactoryTests.cs
@@ -91,7 +91,8 @@ public sealed class HttpMessageFactoryTests
     [InlineData(HttpStatusCode.Created)]
     [InlineData(HttpStatusCode.BadRequest)]
     [InlineData(HttpStatusCode.InternalServerError)]
-    public void FromResponse_AcceptsVariousStatusCodes(HttpStatusCode statusCode)
+    public void FromResponse_AcceptsVariousStatusCodes(
+        HttpStatusCode statusCode)
     {
         // Arrange
         var sut = CreateSut();

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderAdditionalTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderAdditionalTests.cs
@@ -4,7 +4,8 @@ public sealed class MessageRequestBuilderAdditionalTests
 {
     private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
 
-    private MessageRequestBuilder CreateSut(string template = "/api") => new(template, serializer);
+    private MessageRequestBuilder CreateSut(string template = "/api")
+        => new(template, serializer);
 
     [Fact]
     public void Build_WithNoContent_ReturnsMessageWithNullContent()

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderFileContentTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderFileContentTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable IDE0230
 namespace Atc.Rest.Client.Tests.Builder;
 
 public sealed class MessageRequestBuilderFileContentTests
@@ -210,76 +211,101 @@ public sealed class MessageRequestBuilderFileContentTests
         serializer.Received(1).Serialize(notAFile);
     }
 
-    private sealed class TestFileContent : IFileContent
+    [Fact]
+    public void DuckTyping_IBrowserFileShape_PassesLongMaxValueAsMaxAllowedSize()
     {
-        private readonly byte[] data;
+        // Arrange
+        var sut = CreateSut();
+        var browserFile = new CapturingBrowserFileLike("doc.pdf", "application/pdf", [1, 2, 3]);
 
-        public TestFileContent(
-            string fileName,
-            string? contentType,
-            byte[] data)
-        {
-            FileName = fileName;
-            ContentType = contentType;
-            this.data = data;
-        }
+        // Act
+        sut.WithBody(browserFile);
+        sut.Build(HttpMethod.Post);
 
-        public string FileName { get; }
-
-        public string? ContentType { get; }
-
-        public Stream OpenReadStream() => new MemoryStream(data);
+        // Assert — ReflectedFileContent must pass long.MaxValue, not the 512000 default
+        browserFile.CapturedMaxAllowedSize.Should().Be(long.MaxValue);
     }
 
-    /// <summary>
-    /// Mimics the shape of IFormFile: FileName property + parameterless OpenReadStream().
-    /// </summary>
-    [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IFormFile.OpenReadStream() method shape for duck-typing test")]
-    internal sealed class FormFileLike
+    [Fact]
+    public void DuckTyping_IBrowserFileShape_PassesCancellationTokenNone()
     {
-        private readonly byte[] data;
+        // Arrange
+        var sut = CreateSut();
+        var browserFile = new CapturingBrowserFileLike("doc.pdf", "application/pdf", [1, 2, 3]);
 
-        public FormFileLike(
-            string fileName,
-            string contentType,
-            byte[] data)
-        {
-            FileName = fileName;
-            ContentType = contentType;
-            this.data = data;
-        }
+        // Act
+        sut.WithBody(browserFile);
+        sut.Build(HttpMethod.Post);
 
-        public string FileName { get; }
-
-        public string ContentType { get; }
-
-        public Stream OpenReadStream() => new MemoryStream(data);
+        // Assert
+        browserFile.CapturedCancellationToken.Should().Be(CancellationToken.None);
     }
 
-    /// <summary>
-    /// Mimics the shape of IBrowserFile: Name property + OpenReadStream(long, CancellationToken) with defaults.
-    /// </summary>
-    [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IBrowserFile.OpenReadStream() method shape for duck-typing test")]
-    internal sealed class BrowserFileLike
+    [Fact]
+    public void WithBody_IFileContent_NonSeekableStream_ProducesMultipartContent()
     {
-        private readonly byte[] data;
+        // Arrange
+        var sut = CreateSut();
+        var fileContent = new NonSeekableFileContent("stream.bin", "application/octet-stream", [10, 20, 30]);
 
-        public BrowserFileLike(
-            string name,
-            string contentType,
-            byte[] data)
-        {
-            Name = name;
-            ContentType = contentType;
-            this.data = data;
-        }
+        // Act
+        sut.WithBody(fileContent);
+        var message = sut.Build(HttpMethod.Post);
 
-        public string Name { get; }
+        // Assert — CopyTo must work even when the stream does not support Length/Position
+        message.Content.Should().BeOfType<MultipartFormDataContent>();
+    }
 
-        public string ContentType { get; }
+    [Fact]
+    public async Task WithBody_IFileContent_NonSeekableStream_ContainsCorrectBytes()
+    {
+        // Arrange
+        var sut = CreateSut();
+        byte[] data = [10, 20, 30];
+        var fileContent = new NonSeekableFileContent("stream.bin", "application/octet-stream", data);
 
-        public Stream OpenReadStream(
-            long maxAllowedSize = 512000,
-            CancellationToken cancellationToken = default) => new MemoryStream(data);
+        // Act
+        sut.WithBody(fileContent);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = (MultipartFormDataContent)message.Content!;
+        var bytes = await multipart.First().ReadAsByteArrayAsync();
+        bytes.Should().BeEquivalentTo(data);
+    }
+
+    [Fact]
+    public async Task WithBody_IFileContent_EmptyStream_ProducesEmptyContent()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var fileContent = new NonSeekableFileContent("empty.bin", null, []);
+
+        // Act
+        sut.WithBody(fileContent);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = (MultipartFormDataContent)message.Content!;
+        var bytes = await multipart.First().ReadAsByteArrayAsync();
+        bytes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DuckTyping_NonSeekableBrowserFileLike_ContainsCorrectBytes()
+    {
+        // Arrange — end-to-end: duck-typing + long.MaxValue + non-seekable stream
+        var sut = CreateSut();
+        byte[] data = [99, 100, 101, 102];
+        var browserFile = new NonSeekableBrowserFileLike("blob.dat", "application/octet-stream", data);
+
+        // Act
+        sut.WithBody(browserFile);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = (MultipartFormDataContent)message.Content!;
+        var bytes = await multipart.First().ReadAsByteArrayAsync();
+        bytes.Should().BeEquivalentTo(data);
     }
 }

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderFileContentTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderFileContentTests.cs
@@ -1,0 +1,273 @@
+namespace Atc.Rest.Client.Tests.Builder;
+
+public sealed class MessageRequestBuilderFileContentTests
+{
+    private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
+
+    private MessageRequestBuilder CreateSut(string template = "/test") => new(template, serializer);
+
+    [Fact]
+    public void WithBody_IFileContent_Single_ProducesMultipartContent()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var fileContent = new TestFileContent("report.pdf", "application/pdf", [1, 2, 3]);
+
+        // Act
+        sut.WithBody(fileContent);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        message.Content.Should().BeOfType<MultipartFormDataContent>();
+    }
+
+    [Fact]
+    public async Task WithBody_IFileContent_Single_ContainsFileBytes()
+    {
+        // Arrange
+        var sut = CreateSut();
+        byte[] data = [10, 20, 30];
+        var fileContent = new TestFileContent("data.bin", null, data);
+
+        // Act
+        sut.WithBody(fileContent);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = message.Content.Should().BeOfType<MultipartFormDataContent>().Subject;
+        var parts = multipart.ToList();
+        parts.Should().HaveCount(1);
+        var bytes = await parts[0].ReadAsByteArrayAsync();
+        bytes.Should().BeEquivalentTo(data);
+    }
+
+    [Fact]
+    public void WithBody_IFileContent_Single_SetsAcceptToOctetStream()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var fileContent = new TestFileContent("file.txt", "text/plain", [1]);
+
+        // Act
+        sut.WithBody(fileContent);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        message.Headers.Accept.Should().Contain(h => h.MediaType == "application/octet-stream");
+    }
+
+    [Fact]
+    public void WithBody_IFileContent_Single_SetsContentType()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var fileContent = new TestFileContent("image.png", "image/png", [1, 2]);
+
+        // Act
+        sut.WithBody(fileContent);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = (MultipartFormDataContent)message.Content!;
+        var part = multipart.First();
+        part.Headers.ContentType!.MediaType.Should().Be("image/png");
+    }
+
+    [Fact]
+    public void WithBody_IFileContentList_ProducesMultipartContent()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var files = new List<IFileContent>
+        {
+            new TestFileContent("a.txt", "text/plain", [1]),
+            new TestFileContent("b.txt", "text/plain", [2]),
+        };
+
+        // Act
+        sut.WithBody(files);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = message.Content.Should().BeOfType<MultipartFormDataContent>().Subject;
+        multipart.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void DuckTyping_IFormFileShape_ProducesMultipartContent()
+    {
+        // Arrange — synthetic class matching IFormFile shape (FileName + parameterless OpenReadStream)
+        var sut = CreateSut();
+        var formFileLike = new FormFileLike("upload.csv", "text/csv", [7, 8, 9]);
+
+        // Act
+        sut.WithBody(formFileLike);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        message.Content.Should().BeOfType<MultipartFormDataContent>();
+    }
+
+    [Fact]
+    public async Task DuckTyping_IFormFileShape_ContainsCorrectBytes()
+    {
+        // Arrange
+        var sut = CreateSut();
+        byte[] data = [7, 8, 9];
+        var formFileLike = new FormFileLike("upload.csv", "text/csv", data);
+
+        // Act
+        sut.WithBody(formFileLike);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = (MultipartFormDataContent)message.Content!;
+        var bytes = await multipart.First().ReadAsByteArrayAsync();
+        bytes.Should().BeEquivalentTo(data);
+    }
+
+    [Fact]
+    public void DuckTyping_IBrowserFileShape_ProducesMultipartContent()
+    {
+        // Arrange — synthetic class matching IBrowserFile shape (Name + OpenReadStream(long, CancellationToken))
+        var sut = CreateSut();
+        var browserFileLike = new BrowserFileLike("photo.jpg", "image/jpeg", [4, 5, 6]);
+
+        // Act
+        sut.WithBody(browserFileLike);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        message.Content.Should().BeOfType<MultipartFormDataContent>();
+    }
+
+    [Fact]
+    public async Task DuckTyping_IBrowserFileShape_ContainsCorrectBytes()
+    {
+        // Arrange
+        var sut = CreateSut();
+        byte[] data = [4, 5, 6];
+        var browserFileLike = new BrowserFileLike("photo.jpg", "image/jpeg", data);
+
+        // Act
+        sut.WithBody(browserFileLike);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = (MultipartFormDataContent)message.Content!;
+        var bytes = await multipart.First().ReadAsByteArrayAsync();
+        bytes.Should().BeEquivalentTo(data);
+    }
+
+    [Fact]
+    public void DuckTyping_ListOfFormFileLike_ProducesMultipartContent()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var files = new List<FormFileLike>
+        {
+            new("a.txt", "text/plain", [1]),
+            new("b.txt", "text/plain", [2]),
+        };
+
+        // Act
+        sut.WithBody(files);
+        var message = sut.Build(HttpMethod.Post);
+
+        // Assert
+        var multipart = message.Content.Should().BeOfType<MultipartFormDataContent>().Subject;
+        multipart.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void PlainObject_StillJsonSerializes()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var poco = new { Name = "test", Value = 42 };
+
+        // Act
+        sut.WithBody(poco);
+        sut.Build(HttpMethod.Post);
+
+        // Assert
+        serializer.Received(1).Serialize(poco);
+    }
+
+    [Fact]
+    public void DuckTyping_ObjectWithoutOpenReadStream_FallsBackToJson()
+    {
+        // Arrange — has FileName but no OpenReadStream
+        var sut = CreateSut();
+        var notAFile = new { FileName = "trick.txt" };
+
+        // Act
+        sut.WithBody(notAFile);
+        sut.Build(HttpMethod.Post);
+
+        // Assert
+        serializer.Received(1).Serialize(notAFile);
+    }
+
+    private sealed class TestFileContent : IFileContent
+    {
+        private readonly byte[] data;
+
+        public TestFileContent(string fileName, string? contentType, byte[] data)
+        {
+            FileName = fileName;
+            ContentType = contentType;
+            this.data = data;
+        }
+
+        public string FileName { get; }
+
+        public string? ContentType { get; }
+
+        public Stream OpenReadStream() => new MemoryStream(data);
+    }
+
+    /// <summary>
+    /// Mimics the shape of IFormFile: FileName property + parameterless OpenReadStream().
+    /// </summary>
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IFormFile.OpenReadStream() method shape for duck-typing test")]
+    internal sealed class FormFileLike
+    {
+        private readonly byte[] data;
+
+        public FormFileLike(string fileName, string contentType, byte[] data)
+        {
+            FileName = fileName;
+            ContentType = contentType;
+            this.data = data;
+        }
+
+        public string FileName { get; }
+
+        public string ContentType { get; }
+
+        public Stream OpenReadStream() => new MemoryStream(data);
+    }
+
+    /// <summary>
+    /// Mimics the shape of IBrowserFile: Name property + OpenReadStream(long, CancellationToken) with defaults.
+    /// </summary>
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IBrowserFile.OpenReadStream() method shape for duck-typing test")]
+    internal sealed class BrowserFileLike
+    {
+        private readonly byte[] data;
+
+        public BrowserFileLike(string name, string contentType, byte[] data)
+        {
+            Name = name;
+            ContentType = contentType;
+            this.data = data;
+        }
+
+        public string Name { get; }
+
+        public string ContentType { get; }
+
+        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default) => new MemoryStream(data);
+    }
+}

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderFileContentTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderFileContentTests.cs
@@ -4,7 +4,8 @@ public sealed class MessageRequestBuilderFileContentTests
 {
     private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
 
-    private MessageRequestBuilder CreateSut(string template = "/test") => new(template, serializer);
+    private MessageRequestBuilder CreateSut(string template = "/test")
+        => new(template, serializer);
 
     [Fact]
     public void WithBody_IFileContent_Single_ProducesMultipartContent()
@@ -213,7 +214,10 @@ public sealed class MessageRequestBuilderFileContentTests
     {
         private readonly byte[] data;
 
-        public TestFileContent(string fileName, string? contentType, byte[] data)
+        public TestFileContent(
+            string fileName,
+            string? contentType,
+            byte[] data)
         {
             FileName = fileName;
             ContentType = contentType;
@@ -235,7 +239,10 @@ public sealed class MessageRequestBuilderFileContentTests
     {
         private readonly byte[] data;
 
-        public FormFileLike(string fileName, string contentType, byte[] data)
+        public FormFileLike(
+            string fileName,
+            string contentType,
+            byte[] data)
         {
             FileName = fileName;
             ContentType = contentType;
@@ -257,7 +264,10 @@ public sealed class MessageRequestBuilderFileContentTests
     {
         private readonly byte[] data;
 
-        public BrowserFileLike(string name, string contentType, byte[] data)
+        public BrowserFileLike(
+            string name,
+            string contentType,
+            byte[] data)
         {
             Name = name;
             ContentType = contentType;
@@ -268,6 +278,8 @@ public sealed class MessageRequestBuilderFileContentTests
 
         public string ContentType { get; }
 
-        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default) => new MemoryStream(data);
+        public Stream OpenReadStream(
+            long maxAllowedSize = 512000,
+            CancellationToken cancellationToken = default) => new MemoryStream(data);
     }
 }

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderMultipartTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderMultipartTests.cs
@@ -4,7 +4,8 @@ public sealed class MessageRequestBuilderMultipartTests
 {
     private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
 
-    private MessageRequestBuilder CreateSut(string template = "/test") => new(template, serializer);
+    private MessageRequestBuilder CreateSut(string template = "/test")
+        => new(template, serializer);
 
     [Fact]
     public void WithFile_AddsFileToRequest()

--- a/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageRequestBuilderTests.cs
@@ -4,8 +4,7 @@ public sealed class MessageRequestBuilderTests
 {
     private readonly IContractSerializer serializer = Substitute.For<IContractSerializer>();
 
-    private MessageRequestBuilder CreateSut(
-        string? pathTemplate = null)
+    private MessageRequestBuilder CreateSut(string? pathTemplate = null)
         => new(pathTemplate ?? "api/", serializer);
 
     [Fact]
@@ -134,7 +133,8 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Replace_Query_Parameters_With_Enum_Member_Value(string template)
+    public void Should_Replace_Query_Parameters_With_Enum_Member_Value(
+        string template)
     {
         const OperatorRole operatorRole = OperatorRole.Owner;
         var sut = CreateSut(template);
@@ -151,7 +151,8 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Replace_Query_Parameters_With_Enum_Without_EnumMember_Attribute(string template)
+    public void Should_Replace_Query_Parameters_With_Enum_Without_EnumMember_Attribute(
+        string template)
     {
         // OperatorRole.None does not have an EnumMember attribute, so it should fall back to ToString()
         const OperatorRole operatorRole = OperatorRole.None;
@@ -205,7 +206,8 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Replace_Query_Parameters_With_DateTimeOffset(string template)
+    public void Should_Replace_Query_Parameters_With_DateTimeOffset(
+        string template)
     {
         var from = DateTimeOffset.UtcNow;
 
@@ -313,8 +315,7 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Omit_Query_Parameters_With_Empty_Array(
-        string template)
+    public void Should_Omit_Query_Parameters_With_Empty_Array(string template)
     {
         var sut = CreateSut(template);
 
@@ -330,8 +331,7 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Omit_Query_Parameters_With_Empty_List(
-        string template)
+    public void Should_Omit_Query_Parameters_With_Empty_List(string template)
     {
         var sut = CreateSut(template);
 
@@ -408,7 +408,8 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Replace_Query_Parameters_With_Array_Containing_Special_Characters(string template)
+    public void Should_Replace_Query_Parameters_With_Array_Containing_Special_Characters(
+        string template)
     {
         var sut = CreateSut(template);
 
@@ -425,7 +426,8 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Replace_Query_Parameters_With_Single_Item_Array(string template)
+    public void Should_Replace_Query_Parameters_With_Single_Item_Array(
+        string template)
     {
         var sut = CreateSut(template);
 
@@ -443,7 +445,8 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Handle_Query_Parameters_With_Nullable_Enum(string template)
+    public void Should_Handle_Query_Parameters_With_Nullable_Enum(
+        string template)
     {
         OperatorRole? nullableRole = OperatorRole.Admin;
         var sut = CreateSut(template);
@@ -460,7 +463,8 @@ public sealed class MessageRequestBuilderTests
 
     [Theory]
     [InlineAutoNSubstituteData("/api")]
-    public void Should_Omit_Query_Parameters_With_Null_Nullable_Enum(string template)
+    public void Should_Omit_Query_Parameters_With_Null_Nullable_Enum(
+        string template)
     {
         OperatorRole? nullableRole = null;
         var sut = CreateSut(template);

--- a/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderBinaryTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderBinaryTests.cs
@@ -96,7 +96,9 @@ public sealed class MessageResponseBuilderBinaryTests
     [InlineData(HttpStatusCode.BadRequest, false)]
     [InlineData(HttpStatusCode.NotFound, false)]
     [InlineData(HttpStatusCode.InternalServerError, false)]
-    public async Task BuildBinaryResponseAsync_RespectsHttpStatusCode(HttpStatusCode statusCode, bool expectedSuccess)
+    public async Task BuildBinaryResponseAsync_RespectsHttpStatusCode(
+        HttpStatusCode statusCode,
+        bool expectedSuccess)
     {
         // Arrange
         using var response = new HttpResponseMessage(statusCode)
@@ -207,7 +209,9 @@ public sealed class MessageResponseBuilderBinaryTests
     [InlineData(HttpStatusCode.BadRequest, false)]
     [InlineData(HttpStatusCode.Unauthorized, false)]
     [InlineData(HttpStatusCode.InternalServerError, false)]
-    public async Task BuildStreamBinaryResponseAsync_RespectsHttpStatusCode(HttpStatusCode statusCode, bool expectedSuccess)
+    public async Task BuildStreamBinaryResponseAsync_RespectsHttpStatusCode(
+        HttpStatusCode statusCode,
+        bool expectedSuccess)
     {
         // Arrange
         using var response = new HttpResponseMessage(statusCode)

--- a/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderStreamingTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderStreamingTests.cs
@@ -223,7 +223,8 @@ public sealed class MessageResponseBuilderStreamingTests
     [InlineData(HttpStatusCode.OK)]
     [InlineData(HttpStatusCode.Created)]
     [InlineData(HttpStatusCode.Accepted)]
-    public async Task BuildStreamingResponseAsync_SuccessStatusCodes_YieldItems(HttpStatusCode statusCode)
+    public async Task BuildStreamingResponseAsync_SuccessStatusCodes_YieldItems(
+        HttpStatusCode statusCode)
     {
         // Arrange
         using var response = new HttpResponseMessage(statusCode)
@@ -252,7 +253,8 @@ public sealed class MessageResponseBuilderStreamingTests
     [InlineData(HttpStatusCode.BadRequest)]
     [InlineData(HttpStatusCode.NotFound)]
     [InlineData(HttpStatusCode.InternalServerError)]
-    public async Task BuildStreamingResponseAsync_ErrorStatusCodes_YieldNoItems(HttpStatusCode statusCode)
+    public async Task BuildStreamingResponseAsync_ErrorStatusCodes_YieldNoItems(
+        HttpStatusCode statusCode)
     {
         // Arrange
         using var response = new HttpResponseMessage(statusCode)

--- a/test/Atc.Rest.Client.Tests/EndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/EndpointResponseTests.cs
@@ -419,23 +419,4 @@ public class EndpointResponseTests
         // Assert
         sut.Content.Should().Be(expectedContent);
     }
-
-    private sealed class TestableEndpointResponse : EndpointResponse
-    {
-        public TestableEndpointResponse(
-            bool isSuccess,
-            HttpStatusCode statusCode,
-            string content,
-            object? contentObject,
-            IReadOnlyDictionary<string, IEnumerable<string>> headers)
-            : base(isSuccess, statusCode, content, contentObject, headers)
-        {
-        }
-
-        public InvalidOperationException GetInvalidContentAccessException<TExpected>(
-            HttpStatusCode expectedStatusCode,
-            string propertyName)
-            where TExpected : class
-            => InvalidContentAccessException<TExpected>(expectedStatusCode, propertyName);
-    }
 }

--- a/test/Atc.Rest.Client.Tests/GlobalUsings.cs
+++ b/test/Atc.Rest.Client.Tests/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using System.Net;
 global using System.Net.Http.Headers;
 global using System.Runtime.Serialization;
 global using System.Text.Json;
+global using System.Text.Json.Serialization;
 global using Atc.Rest.Client;
 global using Atc.Rest.Client.Builder;
 global using Atc.Rest.Client.Options;

--- a/test/Atc.Rest.Client.Tests/GlobalUsings.cs
+++ b/test/Atc.Rest.Client.Tests/GlobalUsings.cs
@@ -8,4 +8,5 @@ global using Atc.Rest.Client;
 global using Atc.Rest.Client.Builder;
 global using Atc.Rest.Client.Options;
 global using Atc.Rest.Client.Serialization;
+global using Atc.Rest.Client.Tests.TestTypes;
 global using Microsoft.Extensions.DependencyInjection;

--- a/test/Atc.Rest.Client.Tests/Options/AtcRestClientOptionsTests.cs
+++ b/test/Atc.Rest.Client.Tests/Options/AtcRestClientOptionsTests.cs
@@ -60,11 +60,4 @@ public sealed class AtcRestClientOptionsTests
         sut.BaseAddress.Should().Be(new Uri("https://override.example.com"));
         sut.Timeout.Should().Be(TimeSpan.FromMinutes(2));
     }
-
-    private sealed class DerivedOptions : AtcRestClientOptions
-    {
-        public override Uri? BaseAddress { get; set; } = new Uri("https://override.example.com");
-
-        public override TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(2);
-    }
 }

--- a/test/Atc.Rest.Client.Tests/Options/ServiceCollectionExtensionsTests.cs
+++ b/test/Atc.Rest.Client.Tests/Options/ServiceCollectionExtensionsTests.cs
@@ -366,9 +366,4 @@ public sealed class ServiceCollectionExtensionsTests
         factory.CreateClient("SecureClient").BaseAddress.Should().Be(httpsAddress);
         factory.CreateClient("InsecureClient").BaseAddress.Should().Be(httpAddress);
     }
-
-    [SuppressMessage("Major Code Smell", "S2094:Classes should not be empty", Justification = "Test helper type")]
-    private sealed class TestOptions : AtcRestClientOptions
-    {
-    }
 }

--- a/test/Atc.Rest.Client.Tests/Serialization/DefaultJsonContractSerializerTests.cs
+++ b/test/Atc.Rest.Client.Tests/Serialization/DefaultJsonContractSerializerTests.cs
@@ -1,6 +1,5 @@
 namespace Atc.Rest.Client.Tests.Serialization;
 
-[SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Test helper types")]
 public sealed class DefaultJsonContractSerializerTests
 {
     private readonly DefaultJsonContractSerializer sut = new();
@@ -432,30 +431,5 @@ public sealed class DefaultJsonContractSerializerTests
 
         result.Should().NotBeNull();
         result!.Name.Should().Be("日本語テスト");
-    }
-
-    public sealed record TestModel(string Name, int Value);
-
-    public sealed record StatusContainer(TestStatus Status);
-
-    public enum TestStatus
-    {
-        Inactive,
-        Active,
-        Pending,
-    }
-
-    public sealed class CircularModel
-    {
-        public CircularModel? Self { get; set; }
-    }
-
-    public sealed record DateTimeModel(DateTimeOffset Timestamp);
-
-    public sealed record NestedModel(TestModel? Parent, TestModel? Child);
-
-    [SuppressMessage("Major Code Smell", "S2094:Classes should not be empty", Justification = "Test helper type")]
-    public sealed class EmptyModel
-    {
     }
 }

--- a/test/Atc.Rest.Client.Tests/Serialization/JsonSerializerOptionsExtensionsTests.cs
+++ b/test/Atc.Rest.Client.Tests/Serialization/JsonSerializerOptionsExtensionsTests.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Atc.Rest.Client.Tests.Serialization;
 
 public sealed class JsonSerializerOptionsExtensionsTests
@@ -144,19 +142,31 @@ public sealed class JsonSerializerOptionsExtensionsTests
 
     private sealed class CustomTestConverter : JsonConverter<string>
     {
-        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override string? Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
             => reader.GetString();
 
-        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        public override void Write(
+            Utf8JsonWriter writer,
+            string value,
+            JsonSerializerOptions options)
             => writer.WriteStringValue(value);
     }
 
     private sealed class AnotherTestConverter : JsonConverter<int>
     {
-        public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override int Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
             => reader.GetInt32();
 
-        public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+        public override void Write(
+            Utf8JsonWriter writer,
+            int value,
+            JsonSerializerOptions options)
             => writer.WriteNumberValue(value);
     }
 }

--- a/test/Atc.Rest.Client.Tests/Serialization/JsonSerializerOptionsExtensionsTests.cs
+++ b/test/Atc.Rest.Client.Tests/Serialization/JsonSerializerOptionsExtensionsTests.cs
@@ -139,34 +139,4 @@ public sealed class JsonSerializerOptionsExtensionsTests
         source.Converters.Should().HaveCount(1);
         source.Converters[0].Should().BeSameAs(converter);
     }
-
-    private sealed class CustomTestConverter : JsonConverter<string>
-    {
-        public override string? Read(
-            ref Utf8JsonReader reader,
-            Type typeToConvert,
-            JsonSerializerOptions options)
-            => reader.GetString();
-
-        public override void Write(
-            Utf8JsonWriter writer,
-            string value,
-            JsonSerializerOptions options)
-            => writer.WriteStringValue(value);
-    }
-
-    private sealed class AnotherTestConverter : JsonConverter<int>
-    {
-        public override int Read(
-            ref Utf8JsonReader reader,
-            Type typeToConvert,
-            JsonSerializerOptions options)
-            => reader.GetInt32();
-
-        public override void Write(
-            Utf8JsonWriter writer,
-            int value,
-            JsonSerializerOptions options)
-            => writer.WriteNumberValue(value);
-    }
 }

--- a/test/Atc.Rest.Client.Tests/StreamBinaryEndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/StreamBinaryEndpointResponseTests.cs
@@ -206,23 +206,4 @@ public sealed class StreamBinaryEndpointResponseTests
         sut.IsSuccess.Should().BeTrue();
         sut.ErrorContent.Should().BeNull();
     }
-
-    private sealed class TestableStreamBinaryEndpointResponse : StreamBinaryEndpointResponse
-    {
-        public TestableStreamBinaryEndpointResponse(
-            bool isSuccess,
-            HttpStatusCode statusCode,
-            Stream? contentStream,
-            string? contentType,
-            string? fileName,
-            long? contentLength)
-            : base(isSuccess, statusCode, contentStream, contentType, fileName, contentLength)
-        {
-        }
-
-        public InvalidOperationException GetInvalidContentAccessException(
-            HttpStatusCode expectedStatusCode,
-            string propertyName)
-            => InvalidContentAccessException(expectedStatusCode, propertyName);
-    }
 }

--- a/test/Atc.Rest.Client.Tests/StreamingEndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/StreamingEndpointResponseTests.cs
@@ -161,22 +161,4 @@ public sealed class StreamingEndpointResponseTests
         // Assert
         exception.Message.Should().Contain("OKContent");
     }
-
-    private sealed class TestableStreamingEndpointResponse<T> : StreamingEndpointResponse<T>
-    {
-        public TestableStreamingEndpointResponse(
-            bool isSuccess,
-            HttpStatusCode statusCode,
-            IAsyncEnumerable<T?>? content,
-            string? errorContent,
-            HttpResponseMessage? httpResponse)
-            : base(isSuccess, statusCode, content, errorContent, httpResponse)
-        {
-        }
-
-        public InvalidOperationException GetInvalidContentAccessException(
-            HttpStatusCode expectedStatusCode,
-            string propertyName)
-            => InvalidContentAccessException(expectedStatusCode, propertyName);
-    }
 }

--- a/test/Atc.Rest.Client.Tests/TestTypes/AnotherTestConverter.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/AnotherTestConverter.cs
@@ -1,0 +1,16 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class AnotherTestConverter : JsonConverter<int>
+{
+    public override int Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+        => reader.GetInt32();
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        int value,
+        JsonSerializerOptions options)
+        => writer.WriteNumberValue(value);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/BadResponse.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/BadResponse.cs
@@ -1,4 +1,4 @@
-namespace Atc.Rest.Client.Tests;
+namespace Atc.Rest.Client.Tests.TestTypes;
 
 public class BadResponse
 {

--- a/test/Atc.Rest.Client.Tests/TestTypes/BrowserFileLike.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/BrowserFileLike.cs
@@ -1,0 +1,28 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+/// <summary>
+/// Mimics the shape of IBrowserFile: Name property + OpenReadStream(long, CancellationToken) with defaults.
+/// </summary>
+[SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IBrowserFile.OpenReadStream() method shape for duck-typing test")]
+internal sealed class BrowserFileLike
+{
+    private readonly byte[] data;
+
+    public BrowserFileLike(
+        string name,
+        string contentType,
+        byte[] data)
+    {
+        Name = name;
+        ContentType = contentType;
+        this.data = data;
+    }
+
+    public string Name { get; }
+
+    public string ContentType { get; }
+
+    public Stream OpenReadStream(
+        long maxAllowedSize = 512000,
+        CancellationToken cancellationToken = default) => new MemoryStream(data);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/CapturingBrowserFileLike.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/CapturingBrowserFileLike.cs
@@ -1,0 +1,37 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+/// <summary>
+/// IBrowserFile duck-type shape that captures the arguments passed to OpenReadStream.
+/// </summary>
+[SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IBrowserFile.OpenReadStream() method shape for duck-typing test")]
+internal sealed class CapturingBrowserFileLike
+{
+    private readonly byte[] data;
+
+    public CapturingBrowserFileLike(
+        string name,
+        string contentType,
+        byte[] data)
+    {
+        Name = name;
+        ContentType = contentType;
+        this.data = data;
+    }
+
+    public string Name { get; }
+
+    public string ContentType { get; }
+
+    public long? CapturedMaxAllowedSize { get; private set; }
+
+    public CancellationToken? CapturedCancellationToken { get; private set; }
+
+    public Stream OpenReadStream(
+        long maxAllowedSize = 512000,
+        CancellationToken cancellationToken = default)
+    {
+        CapturedMaxAllowedSize = maxAllowedSize;
+        CapturedCancellationToken = cancellationToken;
+        return new MemoryStream(data);
+    }
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/CircularModel.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/CircularModel.cs
@@ -1,0 +1,6 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+public sealed class CircularModel
+{
+    public CircularModel? Self { get; set; }
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/CustomTestConverter.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/CustomTestConverter.cs
@@ -1,0 +1,16 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class CustomTestConverter : JsonConverter<string>
+{
+    public override string? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+        => reader.GetString();
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        string value,
+        JsonSerializerOptions options)
+        => writer.WriteStringValue(value);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/DateTimeModel.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/DateTimeModel.cs
@@ -1,0 +1,3 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+public sealed record DateTimeModel(DateTimeOffset Timestamp);

--- a/test/Atc.Rest.Client.Tests/TestTypes/DerivedOptions.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/DerivedOptions.cs
@@ -1,0 +1,8 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class DerivedOptions : AtcRestClientOptions
+{
+    public override Uri? BaseAddress { get; set; } = new Uri("https://override.example.com");
+
+    public override TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(2);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/EmptyModel.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/EmptyModel.cs
@@ -1,0 +1,6 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+[SuppressMessage("Major Code Smell", "S2094:Classes should not be empty", Justification = "Test helper type")]
+public sealed class EmptyModel
+{
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/FormFileLike.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/FormFileLike.cs
@@ -1,0 +1,26 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+/// <summary>
+/// Mimics the shape of IFormFile: FileName property + parameterless OpenReadStream().
+/// </summary>
+[SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IFormFile.OpenReadStream() method shape for duck-typing test")]
+internal sealed class FormFileLike
+{
+    private readonly byte[] data;
+
+    public FormFileLike(
+        string fileName,
+        string contentType,
+        byte[] data)
+    {
+        FileName = fileName;
+        ContentType = contentType;
+        this.data = data;
+    }
+
+    public string FileName { get; }
+
+    public string ContentType { get; }
+
+    public Stream OpenReadStream() => new MemoryStream(data);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/NestedModel.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/NestedModel.cs
@@ -1,0 +1,3 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+public sealed record NestedModel(TestModel? Parent, TestModel? Child);

--- a/test/Atc.Rest.Client.Tests/TestTypes/NonSeekableBrowserFileLike.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/NonSeekableBrowserFileLike.cs
@@ -1,0 +1,29 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+/// <summary>
+/// IBrowserFile duck-type shape that returns a non-seekable stream.
+/// End-to-end test of duck-typing + long.MaxValue + non-seekable stream.
+/// </summary>
+[SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Mimics IBrowserFile.OpenReadStream() method shape for duck-typing test")]
+internal sealed class NonSeekableBrowserFileLike
+{
+    private readonly byte[] data;
+
+    public NonSeekableBrowserFileLike(
+        string name,
+        string contentType,
+        byte[] data)
+    {
+        Name = name;
+        ContentType = contentType;
+        this.data = data;
+    }
+
+    public string Name { get; }
+
+    public string ContentType { get; }
+
+    public Stream OpenReadStream(
+        long maxAllowedSize = 512000,
+        CancellationToken cancellationToken = default) => new NonSeekableStream(data);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/NonSeekableFileContent.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/NonSeekableFileContent.cs
@@ -1,0 +1,26 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+/// <summary>
+/// IFileContent implementation that returns a non-seekable stream.
+/// Tests that BuildFormFileContent uses CopyTo (not stream.Length).
+/// </summary>
+internal sealed class NonSeekableFileContent : IFileContent
+{
+    private readonly byte[] data;
+
+    public NonSeekableFileContent(
+        string fileName,
+        string? contentType,
+        byte[] data)
+    {
+        FileName = fileName;
+        ContentType = contentType;
+        this.data = data;
+    }
+
+    public string FileName { get; }
+
+    public string? ContentType { get; }
+
+    public Stream OpenReadStream() => new NonSeekableStream(data);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/NonSeekableStream.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/NonSeekableStream.cs
@@ -1,0 +1,59 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+/// <summary>
+/// A stream wrapper that does not support Length, Position, or Seek.
+/// Simulates the non-seekable stream returned by IBrowserFile.OpenReadStream().
+/// </summary>
+internal sealed class NonSeekableStream : Stream
+{
+    private readonly MemoryStream inner;
+
+    public NonSeekableStream(byte[] data) => inner = new MemoryStream(data);
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(
+        byte[] buffer,
+        int offset,
+        int count)
+        => inner.Read(buffer, offset, count);
+
+    public override long Seek(
+        long offset,
+        SeekOrigin origin)
+        => throw new NotSupportedException();
+
+    public override void SetLength(long value)
+        => throw new NotSupportedException();
+
+    public override void Write(
+        byte[] buffer,
+        int offset,
+        int count)
+        => throw new NotSupportedException();
+
+    public override void Flush()
+        => inner.Flush();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            inner.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/OperatorRole.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/OperatorRole.cs
@@ -1,4 +1,4 @@
-namespace Atc.Rest.Client.Tests.Builder;
+namespace Atc.Rest.Client.Tests.TestTypes;
 
 public enum OperatorRole
 {

--- a/test/Atc.Rest.Client.Tests/TestTypes/StatusContainer.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/StatusContainer.cs
@@ -1,0 +1,3 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+public sealed record StatusContainer(TestStatus Status);

--- a/test/Atc.Rest.Client.Tests/TestTypes/SuccessResponse.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/SuccessResponse.cs
@@ -1,4 +1,4 @@
-namespace Atc.Rest.Client.Tests;
+namespace Atc.Rest.Client.Tests.TestTypes;
 
 public class SuccessResponse
 {

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestFileContent.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestFileContent.cs
@@ -1,0 +1,22 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class TestFileContent : IFileContent
+{
+    private readonly byte[] data;
+
+    public TestFileContent(
+        string fileName,
+        string? contentType,
+        byte[] data)
+    {
+        FileName = fileName;
+        ContentType = contentType;
+        this.data = data;
+    }
+
+    public string FileName { get; }
+
+    public string? ContentType { get; }
+
+    public Stream OpenReadStream() => new MemoryStream(data);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestModel.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestModel.cs
@@ -1,0 +1,3 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+public sealed record TestModel(string Name, int Value);

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestOptions.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestOptions.cs
@@ -1,0 +1,6 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+[SuppressMessage("Major Code Smell", "S2094:Classes should not be empty", Justification = "Test helper type")]
+internal sealed class TestOptions : AtcRestClientOptions
+{
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestStatus.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestStatus.cs
@@ -1,0 +1,8 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+public enum TestStatus
+{
+    Inactive,
+    Active,
+    Pending,
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestableBinaryEndpointResponse.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestableBinaryEndpointResponse.cs
@@ -1,0 +1,20 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class TestableBinaryEndpointResponse : BinaryEndpointResponse
+{
+    public TestableBinaryEndpointResponse(
+        bool isSuccess,
+        HttpStatusCode statusCode,
+        byte[]? content,
+        string? contentType,
+        string? fileName,
+        long? contentLength)
+        : base(isSuccess, statusCode, content, contentType, fileName, contentLength)
+    {
+    }
+
+    public InvalidOperationException GetInvalidContentAccessException(
+        HttpStatusCode expectedStatusCode,
+        string propertyName)
+        => InvalidContentAccessException(expectedStatusCode, propertyName);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestableEndpointResponse.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestableEndpointResponse.cs
@@ -1,0 +1,20 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class TestableEndpointResponse : EndpointResponse
+{
+    public TestableEndpointResponse(
+        bool isSuccess,
+        HttpStatusCode statusCode,
+        string content,
+        object? contentObject,
+        IReadOnlyDictionary<string, IEnumerable<string>> headers)
+        : base(isSuccess, statusCode, content, contentObject, headers)
+    {
+    }
+
+    public InvalidOperationException GetInvalidContentAccessException<TExpected>(
+        HttpStatusCode expectedStatusCode,
+        string propertyName)
+        where TExpected : class
+        => InvalidContentAccessException<TExpected>(expectedStatusCode, propertyName);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestableStreamBinaryEndpointResponse.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestableStreamBinaryEndpointResponse.cs
@@ -1,0 +1,20 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class TestableStreamBinaryEndpointResponse : StreamBinaryEndpointResponse
+{
+    public TestableStreamBinaryEndpointResponse(
+        bool isSuccess,
+        HttpStatusCode statusCode,
+        Stream? contentStream,
+        string? contentType,
+        string? fileName,
+        long? contentLength)
+        : base(isSuccess, statusCode, contentStream, contentType, fileName, contentLength)
+    {
+    }
+
+    public InvalidOperationException GetInvalidContentAccessException(
+        HttpStatusCode expectedStatusCode,
+        string propertyName)
+        => InvalidContentAccessException(expectedStatusCode, propertyName);
+}

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestableStreamingEndpointResponse.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestableStreamingEndpointResponse.cs
@@ -1,0 +1,19 @@
+namespace Atc.Rest.Client.Tests.TestTypes;
+
+internal sealed class TestableStreamingEndpointResponse<T> : StreamingEndpointResponse<T>
+{
+    public TestableStreamingEndpointResponse(
+        bool isSuccess,
+        HttpStatusCode statusCode,
+        IAsyncEnumerable<T?>? content,
+        string? errorContent,
+        HttpResponseMessage? httpResponse)
+        : base(isSuccess, statusCode, content, errorContent, httpResponse)
+    {
+    }
+
+    public InvalidOperationException GetInvalidContentAccessException(
+        HttpStatusCode expectedStatusCode,
+        string propertyName)
+        => InvalidContentAccessException(expectedStatusCode, propertyName);
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="2.0.16" />
+    <PackageReference Include="Atc.Test" Version="2.0.17" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.1.0" />


### PR DESCRIPTION
Removing `Microsoft.AspNetCore.Http` from `Atc.Rest.Client`

## Motivation

`Atc.Rest.Client` targets `netstandard2.0`, which should make it usable from Blazor WebAssembly.
However, the package reference to `Microsoft.AspNetCore.Http` (v2.3.9) prevents this because
`Microsoft.AspNetCore.Http` is not compatible with the browser sandbox (it depends on server-side
primitives that do not exist in WASM).

Removing this dependency would allow `Atc.Rest.Client` to be used in:

- Blazor WebAssembly (client-side)
- .NET MAUI / Xamarin
- Any other environment where ASP.NET Core server packages are unavailable