### PR TITLE
feat(response): remove class constraints to support value types

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,13 +626,10 @@ public interface IMessageResponseBuilder
         CancellationToken cancellationToken);
 
     Task<EndpointResponse<TSuccessContent>> BuildResponseAsync<TSuccessContent>(
-        CancellationToken cancellationToken)
-        where TSuccessContent : class;
+        CancellationToken cancellationToken);
 
     Task<EndpointResponse<TSuccessContent, TErrorContent>> BuildResponseAsync<TSuccessContent, TErrorContent>(
-        CancellationToken cancellationToken)
-        where TSuccessContent : class
-        where TErrorContent : class;
+        CancellationToken cancellationToken);
 
     // 💾 Binary response support
     Task<BinaryEndpointResponse> BuildBinaryResponseAsync(CancellationToken cancellationToken);

--- a/src/Atc.Rest.Client/Builder/IMessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/IMessageResponseBuilder.cs
@@ -54,9 +54,8 @@ public interface IMessageResponseBuilder
     /// <typeparam name="TSuccessContent">The type of the success content.</typeparam>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An <see cref="EndpointResponse{TSuccess}"/> with the typed success content.</returns>
-    Task<EndpointResponse<TSuccessContent>>
-        BuildResponseAsync<TSuccessContent>(CancellationToken cancellationToken)
-        where TSuccessContent : class;
+    Task<EndpointResponse<TSuccessContent>> BuildResponseAsync<TSuccessContent>(
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Builds a typed endpoint response with both success and error content.
@@ -67,9 +66,7 @@ public interface IMessageResponseBuilder
     /// <returns>An <see cref="EndpointResponse{TSuccess, TError}"/> with the typed content.</returns>
     Task<EndpointResponse<TSuccessContent, TErrorContent>>
         BuildResponseAsync<TSuccessContent, TErrorContent>(
-            CancellationToken cancellationToken)
-        where TSuccessContent : class
-        where TErrorContent : class;
+            CancellationToken cancellationToken);
 
     /// <summary>
     /// Builds a binary response from the HTTP response.
@@ -151,4 +148,4 @@ public interface IMessageResponseBuilder
     /// <returns>A <see cref="StreamingEndpointResponse{T}"/> containing the streaming content and response metadata.</returns>
     Task<StreamingEndpointResponse<T>> BuildStreamingEndpointResponseAsync<T>(
         CancellationToken cancellationToken = default);
-}
+}

--- a/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
@@ -101,17 +101,14 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
     }
 
     public Task<EndpointResponse<TSuccessContent>> BuildResponseAsync<TSuccessContent>(
-        CancellationToken cancellationToken)
-        where TSuccessContent : class =>
+        CancellationToken cancellationToken) =>
         BuildResponseAsync(
             r => new EndpointResponse<TSuccessContent>(r),
             cancellationToken);
 
     public Task<EndpointResponse<TSuccessContent, TErrorContent>>
         BuildResponseAsync<TSuccessContent, TErrorContent>(
-            CancellationToken cancellationToken)
-        where TSuccessContent : class
-        where TErrorContent : class =>
+            CancellationToken cancellationToken) =>
         BuildResponseAsync(
             r => new EndpointResponse<TSuccessContent, TErrorContent>(r),
             cancellationToken);

--- a/src/Atc.Rest.Client/EndpointResponse.cs
+++ b/src/Atc.Rest.Client/EndpointResponse.cs
@@ -75,9 +75,9 @@ public class EndpointResponse : IEndpointResponse
     /// <returns>The content object cast to the specified type.</returns>
     /// <exception cref="InvalidCastException">Thrown when the content object cannot be cast to the specified type.</exception>
     protected TResult CastContent<TResult>()
-        where TResult : class
-        => ContentObject as TResult ??
-           throw new InvalidCastException($"ContentObject is not of type {typeof(TResult).Name}");
+        => ContentObject is TResult result
+            ? result
+            : throw new InvalidCastException($"ContentObject is not of type {typeof(TResult).Name}");
 
     /// <summary>
     /// Creates an exception for invalid content access with detailed error information.
@@ -89,7 +89,6 @@ public class EndpointResponse : IEndpointResponse
     protected InvalidOperationException InvalidContentAccessException<TExpected>(
         HttpStatusCode expectedStatusCode,
         string propertyName)
-        where TExpected : class
     {
         var actualType = ContentObject?.GetType().Name ?? "null";
         var expectedType = typeof(TExpected).Name;
@@ -100,4 +99,4 @@ public class EndpointResponse : IEndpointResponse
             $"but got {(int)StatusCode} ({StatusCode}) with {actualType} content. " +
             $"Response: {Content}");
     }
-}
+}

--- a/src/Atc.Rest.Client/EndpointResponse{TSuccess,TError}.cs
+++ b/src/Atc.Rest.Client/EndpointResponse{TSuccess,TError}.cs
@@ -7,8 +7,6 @@ namespace Atc.Rest.Client;
 /// <typeparam name="TError">The type of the error content.</typeparam>
 public class EndpointResponse<TSuccess, TError>
     : EndpointResponse
-    where TSuccess : class
-    where TError : class
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="EndpointResponse{TSuccess, TError}"/> class by copying from another response.
@@ -27,6 +25,10 @@ public class EndpointResponse<TSuccess, TError>
     /// <param name="content">The raw response content as a string.</param>
     /// <param name="contentObject">The deserialized content object.</param>
     /// <param name="headers">The response headers.</param>
+    /// <remarks>
+    /// The <paramref name="contentObject"/> is typed as <see cref="object"/> to allow passing <see langword="null"/>
+    /// even when <typeparamref name="TSuccess"/> or <typeparamref name="TError"/> are value types (e.g., for failure responses).
+    /// </remarks>
     public EndpointResponse(
         bool isSuccess,
         HttpStatusCode statusCode,
@@ -40,10 +42,10 @@ public class EndpointResponse<TSuccess, TError>
     /// <summary>
     /// Gets the success content if the request was successful; otherwise, null.
     /// </summary>
-    public TSuccess? SuccessContent => IsSuccess ? CastContent<TSuccess>() : null;
+    public TSuccess? SuccessContent => IsSuccess ? CastContent<TSuccess>() : default;
 
     /// <summary>
     /// Gets the error content if the request failed; otherwise, null.
     /// </summary>
-    public TError? ErrorContent => !IsSuccess ? CastContent<TError>() : null;
-}
+    public TError? ErrorContent => !IsSuccess ? CastContent<TError>() : default;
+}

--- a/src/Atc.Rest.Client/EndpointResponse{TSuccess}.cs
+++ b/src/Atc.Rest.Client/EndpointResponse{TSuccess}.cs
@@ -6,7 +6,6 @@ namespace Atc.Rest.Client;
 /// <typeparam name="TSuccess">The type of the success content.</typeparam>
 public class EndpointResponse<TSuccess>
     : EndpointResponse
-    where TSuccess : class
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="EndpointResponse{TSuccess}"/> class by copying from another response.
@@ -25,11 +24,15 @@ public class EndpointResponse<TSuccess>
     /// <param name="content">The raw response content as a string.</param>
     /// <param name="contentObject">The deserialized content object.</param>
     /// <param name="headers">The response headers.</param>
+    /// <remarks>
+    /// The <paramref name="contentObject"/> is typed as <see cref="object"/> to allow passing <see langword="null"/>
+    /// even when <typeparamref name="TSuccess"/> is a value type (e.g., for failure responses).
+    /// </remarks>
     public EndpointResponse(
         bool isSuccess,
         HttpStatusCode statusCode,
         string content,
-        TSuccess? contentObject,
+        object? contentObject,
         IReadOnlyDictionary<string, IEnumerable<string>> headers)
         : base(isSuccess, statusCode, content, contentObject, headers)
     {
@@ -38,5 +41,5 @@ public class EndpointResponse<TSuccess>
     /// <summary>
     /// Gets the success content if the request was successful; otherwise, null.
     /// </summary>
-    public TSuccess? SuccessContent => IsSuccess ? CastContent<TSuccess>() : null;
-}
+    public TSuccess? SuccessContent => IsSuccess ? CastContent<TSuccess>() : default;
+}

--- a/test/Atc.Rest.Client.Tests/EndpointResponseTests.cs
+++ b/test/Atc.Rest.Client.Tests/EndpointResponseTests.cs
@@ -324,6 +324,81 @@ public class EndpointResponseTests
             .WithMessage("*BadResponse*");
     }
 
+    [Fact]
+    public void InvalidContentAccessException_WithValueType_ContainsExpectedType()
+    {
+        // Arrange
+        var sut = new TestableEndpointResponse(
+            isSuccess: false,
+            HttpStatusCode.Conflict,
+            "{\"error\":\"conflict\"}",
+            new BadResponse(),
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act
+        var exception = sut.GetInvalidContentAccessException<Guid>(
+            HttpStatusCode.OK,
+            "OkContent");
+
+        // Assert
+        exception.Message.Should().Contain("Guid");
+    }
+
+    [Fact]
+    public void SuccessContent_WithValueType_Returns_Value_Upon_Success()
+    {
+        // Arrange
+        var expectedGuid = Guid.NewGuid();
+        var sut = new EndpointResponse<Guid>(
+            true,
+            HttpStatusCode.OK,
+            expectedGuid.ToString(),
+            expectedGuid,
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+
+        // Act & Assert
+        sut.SuccessContent.Should().Be(expectedGuid);
+    }
+
+    [Fact]
+    public void Constructor_WithValueTypeAndNullContent_ShouldSucceed()
+    {
+        // Arrange
+        var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal);
+
+        // Act
+        var sut = new EndpointResponse<Guid>(
+            false,
+            HttpStatusCode.BadRequest,
+            string.Empty,
+            null,
+            headers);
+
+        // Assert
+        sut.IsSuccess.Should().BeFalse();
+        sut.ContentObject.Should().BeNull();
+    }
+
+    [Fact]
+    public void SuccessContent_WithValueType_WhenContentObjectIsWrongType_ThrowsInvalidCastException()
+    {
+        // Arrange
+        var baseResponse = new EndpointResponse(
+            isSuccess: true,
+            HttpStatusCode.OK,
+            "content",
+            "not-a-guid",
+            new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal));
+        var sut = new EndpointResponse<Guid>(baseResponse);
+
+        // Act
+        var act = () => _ = sut.SuccessContent;
+
+        // Assert
+        act.Should().Throw<InvalidCastException>()
+            .WithMessage("*Guid*");
+    }
+
     [Theory]
     [InlineData(HttpStatusCode.OK)]
     [InlineData(HttpStatusCode.Created)]
@@ -367,9 +442,9 @@ public class EndpointResponseTests
         // Arrange
         var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.Ordinal)
         {
-            { "Content-Type", new[] { "application/json" } },
-            { "X-Request-Id", new[] { "12345" } },
-            { "X-Multi-Value", new[] { "a", "b", "c" } },
+            { "Content-Type", ["application/json"] },
+            { "X-Request-Id", ["12345"] },
+            { "X-Multi-Value", ["a", "b", "c"] },
         };
 
         // Act

--- a/test/Atc.Rest.Client.Tests/TestTypes/TestableEndpointResponse.cs
+++ b/test/Atc.Rest.Client.Tests/TestTypes/TestableEndpointResponse.cs
@@ -15,6 +15,5 @@ internal sealed class TestableEndpointResponse : EndpointResponse
     public InvalidOperationException GetInvalidContentAccessException<TExpected>(
         HttpStatusCode expectedStatusCode,
         string propertyName)
-        where TExpected : class
         => InvalidContentAccessException<TExpected>(expectedStatusCode, propertyName);
 }


### PR DESCRIPTION
  Summary

  The EndpointResponse generic types and helper methods (InvalidContentAccessException<T>, CastContent<T>) had where T : class
  constraints that prevented generated client code from using value types like Guid, int, or DateTime as response content types. This
   caused CS0452 compilation errors in projects using the source generator when an API returns a value type. This PR removes all
  unnecessary class constraints across the response type hierarchy and builder interfaces.

  Changes

  :boom: Breaking Changes

  - Remove where TSuccess : class constraint from EndpointResponse<TSuccess>
  - Remove where TSuccess : class and where TError : class constraints from EndpointResponse<TSuccess, TError>
  - Remove class constraints from IMessageResponseBuilder.BuildResponseAsync generic methods
  - Remove class constraints from MessageResponseBuilder.BuildResponseAsync generic methods

  :bug: Fixes

  - Remove where TExpected : class from InvalidContentAccessException<TExpected> — only uses typeof(TExpected).Name, no reference
  type needed
  - Update CastContent<TResult> to use is pattern matching instead of as operator, enabling value type unboxing

  :sparkles: Features

  - EndpointResponse<TSuccess> and EndpointResponse<TSuccess, TError> now accept value types (Guid, int, bool, DateTime, etc.)

  :memo: Documentation

  - Update README to reflect removed class constraints on IMessageResponseBuilder method signatures

  :white_check_mark: Tests

  - Add value type test coverage: InvalidContentAccessException<Guid>, EndpointResponse<Guid> success/failure/wrong-type scenarios

  Notes

  This is a source-compatible relaxation of constraints — all existing code using reference types continues to work unchanged. For
  value type TSuccess, SuccessContent returns default(TSuccess) (e.g., Guid.Empty) on failure rather than null, since unconstrained
  T? is a nullable annotation only and does not produce Nullable<T> for value types.
