### PR TITLE
Add error response deserialization resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 .idea/
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -493,6 +493,21 @@ var result = await responseBuilder.BuildResponseAsync(
     cancellationToken);
 ```
 
+#### Error Response Deserialization Resilience
+
+When an error response (4xx/5xx) cannot be deserialized to the registered type (e.g., a server returns plain text instead of `ProblemDetails` JSON), the builder falls back to the raw string content instead of throwing. This allows generated result classes to handle the conversion gracefully:
+
+```csharp
+responseBuilder.AddErrorResponse<ProblemDetails>(HttpStatusCode.NotFound);
+
+// If the server returns plain text "Not Found" instead of JSON ProblemDetails,
+// ContentObject will be the raw string "Not Found" (not a ProblemDetails instance).
+// Generated result classes handle this via ProblemDetailsFactory.
+var result = await responseBuilder.BuildResponseAsync(x => x, cancellationToken);
+```
+
+> **Note:** For success responses (2xx), deserialization failures still throw `RestClientDeserializationException` since the response body is the primary payload.
+
 ## 💎 Best Practices
 
 ### Choosing Between Overloads

--- a/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
@@ -67,23 +67,24 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
                 }
                 catch (Exception ex)
                 {
-                    throw new RestClientDeserializationException(
-                        $"Failed to deserialize response content to {serializerInfo.Value.TargetType.Name} for status code {(int)response.StatusCode} ({response.StatusCode})",
-                        ex,
-                        response.StatusCode,
-                        content,
-                        serializerInfo.Value.TargetType);
+                    if (IsSuccessStatus(response))
+                    {
+                        throw new RestClientDeserializationException(
+                            $"Failed to deserialize response content to {serializerInfo.Value.TargetType.Name} for status code {(int)response.StatusCode} ({response.StatusCode})",
+                            ex,
+                            response.StatusCode,
+                            content,
+                            serializerInfo.Value.TargetType);
+                    }
                 }
             }
 
-            var endpointResponse = new EndpointResponse(
+            return factory(new EndpointResponse(
                 IsSuccessStatus(response),
                 response.StatusCode,
                 content,
                 contentResponse,
-                GetHeaders(response));
-
-            return factory(endpointResponse);
+                GetHeaders(response)));
         }
 
         var contentObject = await response
@@ -91,8 +92,7 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
             .ReadAsByteArrayAsync()
             .ConfigureAwait(false);
 
-        return factory(
-            new EndpointResponse(
+        return factory(new EndpointResponse(
                 IsSuccessStatus(response),
                 response.StatusCode,
                 string.Empty,

--- a/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderTests.cs
@@ -314,7 +314,7 @@ public sealed class MessageResponseBuilderTests
     }
 
     [Theory, AutoNSubstituteData]
-    public async Task Should_Include_StatusCode_In_DeserializationException(
+    public async Task Should_Fallback_To_RawString_When_ErrorResponse_Deserialization_Fails(
         CancellationToken cancellationToken)
     {
         // Arrange
@@ -327,16 +327,15 @@ public sealed class MessageResponseBuilderTests
 
         var sut = CreateSut(response);
 
-        // Act
-        var act = () => sut.AddErrorResponse<BadResponse>(response.StatusCode)
+        // Act - error responses should not throw on deserialization failure
+        var result = await sut.AddErrorResponse<BadResponse>(response.StatusCode)
             .BuildResponseAsync(res => res, cancellationToken);
 
-        // Assert
-        var exception = await act.Should().ThrowAsync<RestClientDeserializationException>();
-        exception.Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        exception.Which.RawContent.Should().Be("{malformed}");
-        exception.Which.TargetType.Should().Be(typeof(BadResponse));
-        exception.Which.Message.Should().Contain(nameof(BadResponse));
+        // Assert - raw string content flows through as ContentObject
+        result.ContentObject.Should().Be("{malformed}");
+        result.Content.Should().Be("{malformed}");
+        result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        result.IsSuccess.Should().BeFalse();
     }
 
     [Theory, AutoNSubstituteData]


### PR DESCRIPTION
  # Summary

  - Fall back to raw string when error response deserialization fails
  - Prevent RestClientDeserializationException on malformed 4xx/5xx bodies
  - Success (2xx) deserialization failures still throw as before

  # Changes

  ### :bug: Fixes
  - Swallow deserialization errors for error responses (4xx/5xx)
  - Return raw string content as ContentObject on failure
  - Preserve throwing behavior for success (2xx) responses

  ### :recycle: Refactoring
  - Inline EndpointResponse construction into return statements

  ### :white_check_mark: Tests
  - Update test to verify fallback behavior instead of exception
  - Rename test to reflect new expected behavior

  ### :memo: Documentation
  - Document error response deserialization resilience in README
  - Add code example showing ProblemDetails fallback scenario

  ### :wrench: Configuration
  - Add `.claude/settings.local.json` to `.gitignore`
