### PR TITLE
Add text/plain response support to IMessageResponseBuilder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 27-11-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: Root
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -441,28 +441,24 @@ dotnet_naming_rule.parameters_rule.severity             = warning
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0003.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0003.md
-dotnet_diagnostic.MA0004.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0006.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0006.md
+dotnet_diagnostic.MA0003.severity = suggestion      # Add argument name to improve readability
+dotnet_diagnostic.MA0004.severity = suggestion      # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0006.severity = none            # Use String.Equals instead of equality operator
 dotnet_diagnostic.MA0011.severity = none            # Duplicate of CA1305
-dotnet_diagnostic.MA0016.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
-dotnet_diagnostic.MA0025.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0025.md
-dotnet_diagnostic.MA0026.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0026.md
-dotnet_diagnostic.MA0028.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0028.md
+dotnet_diagnostic.MA0016.severity = error           # Prefer return collection abstraction over implementation
+dotnet_diagnostic.MA0025.severity = suggestion      # Implement functionality instead of throwing NotImplementedException
+dotnet_diagnostic.MA0026.severity = suggestion      # Fix TODO comment
+dotnet_diagnostic.MA0028.severity = none            # Optimize StringBuilder usage
 dotnet_diagnostic.MA0038.severity = none            # Duplicate of CA1822
-dotnet_diagnostic.MA0048.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0048.md
+dotnet_diagnostic.MA0048.severity = error           # File name must match type name
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1014.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1014.md
-dotnet_diagnostic.CA1068.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
+dotnet_diagnostic.CA1014.severity = none            # Mark assemblies with CLSCompliantAttribute
+dotnet_diagnostic.CA1068.severity = error           # CancellationToken parameters must come last
 dotnet_diagnostic.CA1305.severity = error
 dotnet_diagnostic.CA1308.severity = suggestion      # Normalize strings to uppercase
 dotnet_diagnostic.CA1510.severity = suggestion      # Use ArgumentNullException throw helper
@@ -471,7 +467,7 @@ dotnet_diagnostic.CA1512.severity = suggestion      # Use ArgumentOutOfRangeExce
 dotnet_diagnostic.CA1513.severity = suggestion      # Use ObjectDisposedException throw helper
 dotnet_diagnostic.CA1514.severity = error           # Avoid redundant length argument
 dotnet_diagnostic.CA1515.severity = suggestion      # Because an application's API isn't typically referenced from outside the assembly, types can be made internal (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1515)
-dotnet_diagnostic.CA1707.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
+dotnet_diagnostic.CA1707.severity = error           # Identifiers should not contain underscores
 dotnet_diagnostic.CA1812.severity = none
 dotnet_diagnostic.CA1822.severity = suggestion
 dotnet_diagnostic.CA1849.severity = error           # Call async methods when in an async method
@@ -498,7 +494,7 @@ dotnet_diagnostic.CA1873.severity = suggestion      # Avoid potentially expensiv
 dotnet_diagnostic.CA1874.severity = suggestion      # Use 'Regex.IsMatch' instead of 'Regex.Match(...).Success' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1874)
 dotnet_diagnostic.CA1875.severity = suggestion      # Use 'Regex.Count' instead of 'Regex.Matches(...).Count' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1875)
 dotnet_diagnostic.CA1877.severity = suggestion      # Use 'Path.Combine' or 'Path.Join' overloads (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1877)
-dotnet_diagnostic.CA2007.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
+dotnet_diagnostic.CA2007.severity = suggestion      # Do not directly await a Task
 dotnet_diagnostic.CA2017.severity = error           # Parameter count mismatch
 dotnet_diagnostic.CA2018.severity = error           # The count argument to Buffer.BlockCopy should specify the number of bytes to copy
 dotnet_diagnostic.CA2019.severity = error           # ThreadStatic fields should not use inline initialization
@@ -515,12 +511,12 @@ dotnet_diagnostic.CA2262.severity = suggestion      # Set 'MaxResponseHeadersLen
 dotnet_diagnostic.CA2263.severity = suggestion      # Prefer generic overload when type is known
 dotnet_diagnostic.CA2264.severity = error           # Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'
 dotnet_diagnostic.CA2265.severity = error           # Do not compare Sp an<T> to 'null' or 'default' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2265)
-dotnet_diagnostic.IDE0005.severity = warning        # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0005.md
+dotnet_diagnostic.IDE0005.severity = warning        # Remove unnecessary using directives
 dotnet_diagnostic.IDE0010.severity = suggestion     # Populate switch
 dotnet_diagnostic.IDE0028.severity = suggestion     # Collection initialization can be simplified
 dotnet_diagnostic.IDE0021.severity = suggestion     # Use expression body for constructor
 dotnet_diagnostic.IDE0055.severity = none           # Fix formatting
-dotnet_diagnostic.IDE0058.severity = none           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0058.md
+dotnet_diagnostic.IDE0058.severity = none           # Remove unnecessary expression value
 dotnet_diagnostic.IDE0061.severity = suggestion     # Use expression body for local function
 dotnet_diagnostic.IDE0130.severity = suggestion     # Namespace does not match folder structure
 dotnet_diagnostic.IDE0290.severity = none			# Use primary constructor
@@ -530,38 +526,34 @@ dotnet_diagnostic.IDE0305.severity = suggestion     # Collection initialization 
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
-dotnet_diagnostic.CS4014.severity = error          # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCompilerErrors/CS4014.md
-
-
-# SecurityCodeScan
-# https://security-code-scan.github.io/
+dotnet_diagnostic.CS4014.severity = error           # Call is not awaited
 
 
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1009.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1009.md
+dotnet_diagnostic.SA1009.severity = none            # Closing parenthesis should be spaced correctly
 dotnet_diagnostic.SA1010.severity = none            # False positive when using collection initializers
-dotnet_diagnostic.SA1101.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1101.md
-dotnet_diagnostic.SA1122.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
-dotnet_diagnostic.SA1200.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1200.md
-dotnet_diagnostic.SA1201.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1201.md
-dotnet_diagnostic.SA1202.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1202.md
-dotnet_diagnostic.SA1204.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1204.md
-dotnet_diagnostic.SA1413.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1413.md
-dotnet_diagnostic.SA1600.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1600.md
+dotnet_diagnostic.SA1101.severity = none            # Prefix local calls with this
+dotnet_diagnostic.SA1122.severity = error           # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = error           # Do not combine attributes
+dotnet_diagnostic.SA1200.severity = none            # Using directives should be placed correctly
+dotnet_diagnostic.SA1201.severity = none            # Elements should appear in the correct order
+dotnet_diagnostic.SA1202.severity = none            # Elements should be ordered by access
+dotnet_diagnostic.SA1204.severity = none            # Static elements should appear before instance elements
+dotnet_diagnostic.SA1413.severity = error           # Use trailing commas in multi-line initializers
+dotnet_diagnostic.SA1600.severity = none            # Elements should be documented
 dotnet_diagnostic.SA1601.severity = none
-dotnet_diagnostic.SA1602.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1602.md
-dotnet_diagnostic.SA1604.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1604.md
-dotnet_diagnostic.SA1623.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1623.md
-dotnet_diagnostic.SA1629.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1629.md
-dotnet_diagnostic.SA1633.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1633.md
-dotnet_diagnostic.SA1649.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1649.md
+dotnet_diagnostic.SA1602.severity = none            # Enumeration items should be documented
+dotnet_diagnostic.SA1604.severity = none            # Element documentation should have summary
+dotnet_diagnostic.SA1623.severity = none            # Property summary documentation should match accessors
+dotnet_diagnostic.SA1629.severity = none            # Documentation text should end with a period
+dotnet_diagnostic.SA1633.severity = none            # File should have header
+dotnet_diagnostic.SA1649.severity = error           # File name should match first type name
 
 
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp
-dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
+dotnet_diagnostic.S1135.severity = suggestion       # Track uses of TODO tags
 dotnet_diagnostic.S2629.severity = none            	# Don't use string interpolation in logging message templates.
 dotnet_diagnostic.S3358.severity = none           	# Extract this nested ternary operation into an independent statement.
 dotnet_diagnostic.S6602.severity = none           	# "Find" method should be used instead of the "FirstOrDefault"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,13 +39,11 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="Atc.Analyzer" Version="0.1.22" PrivateAssets="All" />
+    <PackageReference Include="Atc.Analyzer" Version="0.1.23" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
-    <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.7" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.50" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.19.0.132793" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A lightweight and flexible REST client library for .NET, providing a clean abstr
     - [📋 Handling Responses](#-handling-responses)
       - [Success and Error Response Handling](#success-and-error-response-handling)
       - [Custom Response Processing](#custom-response-processing)
+      - [Plain Text Responses](#plain-text-responses)
+      - [Error Response Deserialization Resilience](#error-response-deserialization-resilience)
   - [💎 Best Practices](#-best-practices)
     - [Choosing Between Overloads](#choosing-between-overloads)
     - [Multiple Client Registration](#multiple-client-registration)
@@ -62,6 +64,7 @@ A lightweight and flexible REST client library for .NET, providing a clean abstr
 - 📎 **Multipart Form Data**: File upload support with Stream-based API
 - 📤 **Binary Uploads**: Raw binary stream uploads (application/octet-stream)
 - 💾 **Binary Responses**: Handle file downloads with byte[] or Stream responses
+- 📝 **Plain Text Responses**: First-class `text/plain` handling that bypasses JSON deserialization
 - 🌊 **Streaming Support**: IAsyncEnumerable streaming for large datasets with proper lifecycle management
 - ⏱️ **HTTP Completion Options**: Control response buffering for streaming scenarios
 
@@ -493,6 +496,42 @@ var result = await responseBuilder.BuildResponseAsync(
     cancellationToken);
 ```
 
+#### Plain Text Responses
+
+For endpoints that return a `text/plain` (or other `text/*`) body with a `type: string` schema, use `AddSuccessTextResponse` / `AddErrorTextResponse`. These bypass the contract serializer entirely and return the body verbatim — no JSON parsing, no exceptions on non-JSON content:
+
+```csharp
+var requestBuilder = messageFactory.FromTemplate("/api/reports/{id}/text");
+requestBuilder.WithPathParameter("id", "123");
+
+using var request = requestBuilder.Build(HttpMethod.Get);
+using var response = await client.SendAsync(request, cancellationToken);
+
+var responseBuilder = messageFactory.FromResponse(response);
+responseBuilder.AddSuccessTextResponse(HttpStatusCode.OK);
+responseBuilder.AddErrorTextResponse(HttpStatusCode.BadRequest);
+
+var result = await responseBuilder.BuildResponseAsync<string, string>(cancellationToken);
+
+if (result.IsSuccess)
+{
+    // SuccessContent is the raw body, e.g. "file contents"
+    Console.WriteLine(result.SuccessContent);
+}
+else
+{
+    // ErrorContent is the raw error body, e.g. "validation failed"
+    Console.WriteLine($"❌ {result.StatusCode}: {result.ErrorContent}");
+}
+```
+
+> 💡 **When to use `AddSuccessTextResponse` vs `AddSuccessResponse<string>`:**
+>
+> - Use `AddSuccessTextResponse` when the server returns a raw text body (e.g. `file contents`). The default JSON serializer would reject this since it's not a valid JSON literal.
+> - Use `AddSuccessResponse<string>` only when the server returns a JSON-encoded string (e.g. `"file contents"` with quotes).
+>
+> An empty or whitespace-only body yields a `null` `ContentObject`, matching the behavior of `AddSuccessResponse<T>`. Character encoding follows the `Content-Type` charset.
+
 #### Error Response Deserialization Resilience
 
 When an error response (4xx/5xx) cannot be deserialized to the registered type (e.g., a server returns plain text instead of `ProblemDetails` JSON), the builder falls back to the raw string content instead of throwing. This allows generated result classes to handle the conversion gracefully:
@@ -635,6 +674,10 @@ public interface IMessageResponseBuilder
     IMessageResponseBuilder AddSuccessResponse<TResponseContent>(HttpStatusCode statusCode);
     IMessageResponseBuilder AddErrorResponse(HttpStatusCode statusCode);
     IMessageResponseBuilder AddErrorResponse<TResponseContent>(HttpStatusCode statusCode);
+
+    // 📝 Plain text response support (text/*, bypasses serializer)
+    IMessageResponseBuilder AddSuccessTextResponse(HttpStatusCode statusCode);
+    IMessageResponseBuilder AddErrorTextResponse(HttpStatusCode statusCode);
 
     Task<TResult> BuildResponseAsync<TResult>(
         Func<EndpointResponse, TResult> factory,

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 27-11-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: src
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -14,10 +14,6 @@
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
 
@@ -28,10 +24,6 @@
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
-
-
-# SecurityCodeScan
-# https://security-code-scan.github.io/
 
 
 # StyleCop

--- a/src/Atc.Rest.Client/Builder/IMessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/IMessageResponseBuilder.cs
@@ -38,6 +38,38 @@ public interface IMessageResponseBuilder
         HttpStatusCode statusCode);
 
     /// <summary>
+    /// Registers a status code as a success response whose body is plain text.
+    /// The body is returned verbatim as a <see cref="string"/> without any JSON
+    /// or other deserialization.
+    /// </summary>
+    /// <remarks>
+    /// Use this for endpoints that declare a <c>text/plain</c> (or other <c>text/*</c>) response.
+    /// The body is read via <see cref="HttpContent.ReadAsStringAsync()"/>, which honors the
+    /// charset declared in the <c>Content-Type</c> header.
+    /// An empty or whitespace-only body yields a <see langword="null"/> <c>ContentObject</c>,
+    /// matching the behavior of <see cref="AddSuccessResponse{TResponseContent}(HttpStatusCode)"/>.
+    /// </remarks>
+    /// <param name="statusCode">The HTTP status code to treat as success.</param>
+    /// <returns>The <see cref="IMessageResponseBuilder"/>.</returns>
+    IMessageResponseBuilder AddSuccessTextResponse(HttpStatusCode statusCode);
+
+    /// <summary>
+    /// Registers a status code as an error response whose body is plain text.
+    /// The body is returned verbatim as a <see cref="string"/> without any JSON
+    /// or other deserialization.
+    /// </summary>
+    /// <remarks>
+    /// Use this for endpoints that declare a <c>text/plain</c> (or other <c>text/*</c>) error response.
+    /// The body is read via <see cref="HttpContent.ReadAsStringAsync()"/>, which honors the
+    /// charset declared in the <c>Content-Type</c> header.
+    /// An empty or whitespace-only body yields a <see langword="null"/> <c>ContentObject</c>,
+    /// matching the behavior of <see cref="AddErrorResponse{TResponseContent}(HttpStatusCode)"/>.
+    /// </remarks>
+    /// <param name="statusCode">The HTTP status code to treat as error.</param>
+    /// <returns>The <see cref="IMessageResponseBuilder"/>.</returns>
+    IMessageResponseBuilder AddErrorTextResponse(HttpStatusCode statusCode);
+
+    /// <summary>
     /// Builds the response using a custom factory function.
     /// </summary>
     /// <typeparam name="TResult">The type of result to create.</typeparam>

--- a/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
+++ b/src/Atc.Rest.Client/Builder/MessageResponseBuilder.cs
@@ -41,6 +41,14 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
         HttpStatusCode statusCode)
         => AddTypedResponse<TResponseContent>(statusCode, isSuccess: true);
 
+    public IMessageResponseBuilder AddSuccessTextResponse(
+        HttpStatusCode statusCode)
+        => AddTextResponse(statusCode, isSuccess: true);
+
+    public IMessageResponseBuilder AddErrorTextResponse(
+        HttpStatusCode statusCode)
+        => AddTextResponse(statusCode, isSuccess: false);
+
     public async Task<TResult> BuildResponseAsync<TResult>(
         Func<EndpointResponse, TResult> factory,
         CancellationToken cancellationToken)
@@ -328,6 +336,18 @@ internal class MessageResponseBuilder : IMessageResponseBuilder
                 ? null
                 : serializer.Deserialize<T>(content),
             typeof(T));
+        responseCodes[statusCode] = isSuccess;
+
+        return this;
+    }
+
+    private IMessageResponseBuilder AddTextResponse(
+        HttpStatusCode statusCode,
+        bool isSuccess)
+    {
+        responseSerializers[statusCode] = (
+            content => string.IsNullOrWhiteSpace(content) ? null : content,
+            typeof(string));
         responseCodes[statusCode] = isSuccess;
 
         return this;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,7 +53,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 27-11-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: test
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -14,37 +14,30 @@
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0004.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0016.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
+dotnet_diagnostic.MA0004.severity = none            # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0016.severity = none            # Prefer return collection abstraction over implementation
 dotnet_diagnostic.MA0051.severity = none            # Method Length
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1068.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
-dotnet_diagnostic.CA1602.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1602.md
-dotnet_diagnostic.CA1707.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
-dotnet_diagnostic.CA2007.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
+dotnet_diagnostic.CA1068.severity = none            # CancellationToken parameters must come last
+dotnet_diagnostic.CA1602.severity = none
+dotnet_diagnostic.CA1707.severity = none            # Identifiers should not contain underscores
+dotnet_diagnostic.CA2007.severity = none            # Do not directly await a Task
+dotnet_diagnostic.CA2025.severity = none            # Ensure tasks using 'IDisposable' instances complete before the instances are disposed
 
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
 
 
-# SecurityCodeScan
-# https://security-code-scan.github.io/
-
-
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1122.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
+dotnet_diagnostic.SA1122.severity = none            # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = none            # Do not combine attributes
 
 
 # SonarAnalyzer.CSharp

--- a/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderTests.cs
+++ b/test/Atc.Rest.Client.Tests/Builder/MessageResponseBuilderTests.cs
@@ -745,4 +745,183 @@ public sealed class MessageResponseBuilderTests
         result.Content.Should().BeNull();
         result.ErrorContent.Should().BeNull();
     }
+
+    [Theory, AutoNSubstituteData]
+    public async Task AddSuccessTextResponse_RawTextBody_ReturnsContentVerbatim(
+        CancellationToken cancellationToken)
+    {
+        // Arrange - raw text body (NOT a JSON-quoted string)
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("file contents", System.Text.Encoding.UTF8, "text/plain"),
+        };
+
+        var sut = CreateSut(response);
+
+        // Act
+        var result = await sut.AddSuccessTextResponse(response.StatusCode)
+            .BuildResponseAsync<string>(cancellationToken);
+
+        // Assert - body returned verbatim, no JSON-quote processing, no exception
+        result.IsSuccess.Should().BeTrue();
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Content.Should().Be("file contents");
+        result.SuccessContent.Should().Be("file contents");
+    }
+
+    [Theory, AutoNSubstituteData]
+    public async Task AddSuccessTextResponse_RawTextBody_ContentObjectIsStringType(
+        CancellationToken cancellationToken)
+    {
+        // Arrange
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("plain body", System.Text.Encoding.UTF8, "text/plain"),
+        };
+
+        var sut = CreateSut(response);
+
+        // Act
+        var result = await sut.AddSuccessTextResponse(response.StatusCode)
+            .BuildResponseAsync(res => res, cancellationToken);
+
+        // Assert - proves the bypass: ContentObject is the string itself, not a deserialized object
+        result.ContentObject.Should().BeOfType<string>();
+        result.ContentObject.Should().Be("plain body");
+    }
+
+    [Theory, AutoNSubstituteData]
+    public async Task AddSuccessTextResponse_EmptyBody_ReturnsNullContentObject(
+        CancellationToken cancellationToken)
+    {
+        // Arrange - empty text body (mirror AddTypedResponse<T> null-for-whitespace semantics)
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(string.Empty, System.Text.Encoding.UTF8, "text/plain"),
+        };
+
+        var sut = CreateSut(response);
+
+        // Act
+        var result = await sut.AddSuccessTextResponse(response.StatusCode)
+            .BuildResponseAsync(res => res, cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.ContentObject.Should().BeNull();
+    }
+
+    [Theory, AutoNSubstituteData]
+    public async Task AddSuccessTextResponse_DoesNotInvokeContractSerializer(
+        CancellationToken cancellationToken)
+    {
+        // Arrange - body that would throw if pushed through JSON deserialization
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("not { valid json", System.Text.Encoding.UTF8, "text/plain"),
+        };
+
+        var sut = CreateSut(response);
+
+        // Act - must not throw RestClientDeserializationException
+        var result = await sut.AddSuccessTextResponse(response.StatusCode)
+            .BuildResponseAsync(res => res, cancellationToken);
+
+        // Assert - content flowed through untouched, serializer was never called
+        result.Content.Should().Be("not { valid json");
+        result.ContentObject.Should().Be("not { valid json");
+        serializer.DidNotReceiveWithAnyArgs().Deserialize<string>((string)null!);
+        serializer.DidNotReceiveWithAnyArgs().Deserialize<string>((byte[])null!);
+    }
+
+    [Theory, AutoNSubstituteData]
+    public async Task AddErrorTextResponse_NonSuccessStatus_ReturnsErrorContent(
+        CancellationToken cancellationToken)
+    {
+        // Arrange
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("validation failed", System.Text.Encoding.UTF8, "text/plain"),
+        };
+
+        var sut = CreateSut(response);
+
+        // Act
+        var result = await sut.AddErrorTextResponse(response.StatusCode)
+            .BuildResponseAsync<string, string>(cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        result.ErrorContent.Should().Be("validation failed");
+    }
+
+    [Theory, AutoNSubstituteData]
+    public async Task AddSuccessTextResponse_AndAddErrorTextResponse_CoexistOnSameBuilder_Success(
+        CancellationToken cancellationToken)
+    {
+        // Arrange
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("ok body", System.Text.Encoding.UTF8, "text/plain"),
+        };
+
+        var sut = CreateSut(response);
+
+        // Act - register both on one builder; exercise the success path
+        var result = await sut
+            .AddSuccessTextResponse(HttpStatusCode.OK)
+            .AddErrorTextResponse(HttpStatusCode.BadRequest)
+            .BuildResponseAsync<string, string>(cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.SuccessContent.Should().Be("ok body");
+    }
+
+    [Theory, AutoNSubstituteData]
+    public async Task AddSuccessTextResponse_AndAddErrorTextResponse_CoexistOnSameBuilder_Error(
+        CancellationToken cancellationToken)
+    {
+        // Arrange
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("bad body", System.Text.Encoding.UTF8, "text/plain"),
+        };
+
+        var sut = CreateSut(response);
+
+        // Act - register both on one builder; exercise the error path
+        var result = await sut
+            .AddSuccessTextResponse(HttpStatusCode.OK)
+            .AddErrorTextResponse(HttpStatusCode.BadRequest)
+            .BuildResponseAsync<string, string>(cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorContent.Should().Be("bad body");
+    }
+
+    [Theory, AutoNSubstituteData]
+    public void AddSuccessTextResponse_FluentChaining_ReturnsBuilder(
+        HttpResponseMessage response)
+    {
+        var sut = CreateSut(response);
+
+        var chained = sut.AddSuccessTextResponse(HttpStatusCode.OK);
+
+        chained.Should().BeSameAs(sut);
+    }
+
+    [Theory, AutoNSubstituteData]
+    public void AddErrorTextResponse_FluentChaining_ReturnsBuilder(
+        HttpResponseMessage response)
+    {
+        var sut = CreateSut(response);
+
+        var chained = sut.AddErrorTextResponse(HttpStatusCode.BadRequest);
+
+        chained.Should().BeSameAs(sut);
+    }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -20,8 +20,8 @@
   <ItemGroup>
     <PackageReference Include="Atc.Test" Version="2.0.17" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
  # Summary

  - Unblock OpenAPI `text/plain` clients from the REST generator
  - Return raw text bodies verbatim without JSON deserialization
  - Refresh atc-coding-rules to 1.0.1 and bump analyzer packages

  # Changes

  ### :sparkles: Features
  - Add `AddSuccessTextResponse(HttpStatusCode)` to the builder
  - Add `AddErrorTextResponse(HttpStatusCode)` to the builder
  - Bypass the contract serializer for registered text status codes
  - Mirror `AddTypedResponse<T>` empty-body semantics (null for whitespace)

  ### :memo: Documentation
  - Add "Plain Text Responses" usage section to README
  - Update `IMessageResponseBuilder` block in the API reference
  - Add Plain Text Responses entry to the Features list and TOC

  ### :package: Dependencies
  - Bump Atc.Analyzer 0.1.22 -> 0.1.23
  - Bump Meziantou.Analyzer 3.0.7 -> 3.0.50
  - Bump SonarAnalyzer.CSharp 10.19.0 -> 10.24.0
  - Bump Microsoft.SourceLink.GitHub 10.0.103 -> 10.0.203
  - Bump Microsoft.Testing.Extensions.CodeCoverage 18.4.1 -> 18.6.2
  - Bump Microsoft.Testing.Extensions.TrxReport 2.1.0 -> 2.2.1

  ### :fire: Removal
  - Drop Asyncify package reference and editorconfig section
  - Drop SecurityCodeScan.VS2019 package reference

  ### :wrench: Configuration
  - Sync all .editorconfig files to atc-coding-rules v1.0.1
  - Replace external rule-URL comments with inline descriptions

  # Notes

  - `Atc.Rest.Client` targets `netstandard2.0`, so default interface
    methods are unavailable - the new methods are plain additions
  - Additive interface change; external implementers of
    `IMessageResponseBuilder` must add the two methods on upgrade
  - Charset is honored via `ReadAsStringAsync`; no extra handling needed
  - Enables the generator to switch `EndpointPerOperation` text clients
    from inline emission to the canonical builder pathway
